### PR TITLE
Integrate with release notifications

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-*       @kleewho @bartk @Chesteer89
+*         @kleewho @bartk @Chesteer89
 .travis/* @parfeon @kleewho @bartk @Chesteer89
-README.md @polarweasel @samiahmedsiddiqui @techwritermat
+README.md @techwritermat @kazydek

--- a/.github/workflows/commands-handler.yml
+++ b/.github/workflows/commands-handler.yml
@@ -24,3 +24,4 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           listener: client-engineering-bot
+          jira-api-key: ${{ secrets.JIRA_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,6 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           source-folder: build/dokka/pubnub-kotlin
-          command: "gradlew dokka"
+          jira-api-key: ${{ secrets.JIRA_API_KEY }}
           last-service: true
 

--- a/.github/workflows/release/pre-github-pages-publish.sh
+++ b/.github/workflows/release/pre-github-pages-publish.sh
@@ -1,0 +1,1 @@
+./gradlew dokka


### PR DESCRIPTION
build: integrate with release notifications

Add support for release process notifications.

fix(build): fix docs build

Move `gradlew` call into separate pre-publish script.