### PR TITLE
Remove v from release version to fix docs

### DIFF
--- a/.github/workflows/release/versions.json
+++ b/.github/workflows/release/versions.json
@@ -1,6 +1,9 @@
 {
   ".pubnub.yml": [
-    { "pattern": "^version: (v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)$", "cleared": false },
+    { "pattern": "^version: (v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)$",
+      "clearedPrefix": true,
+      "clearedSuffix": false
+    },
     {
       "pattern": "^\\s+\\-\\s+build/libs/pubnub-kotlin-(v?(\\d+\\.?){2,}([a-zA-Z0-9-]+(\\.?\\d+)?)?)-all.jar$",
       "clearedPrefix": true,

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,5 +1,5 @@
 name: kotlin
-version: v7.0.0
+version: 7.0.0
 schema: 1
 scm: github.com/pubnub/kotlin
 files:


### PR DESCRIPTION
This PR is removing `v` from the release version and, thus, fixing the Kotlin SDK docs to which the release version is automatically propagated:
<img width="818" alt="Screenshot 2022-04-07 at 14 06 59" src="https://user-images.githubusercontent.com/40655785/162194929-02a6e318-cfd8-469a-ba84-564a8ceb7825.png">

(should be `7.0.0` instead of `v7.0.0`)
See a similar situation for Java that was fixed in this PR: https://github.com/pubnub/java/pull/234/files