### PR TITLE
Add products.json to enable module releases

### DIFF
--- a/.github/workflows/release/products.json
+++ b/.github/workflows/release/products.json
@@ -1,0 +1,22 @@
+{
+  "kotlin": {
+    "path": "./",
+    "name": "Kotlin SDK",
+    "main": true
+  },
+  "users": {
+    "path": "./pubnub-users",
+    "name": "Kotlin Users",
+    "main": false
+  },
+  "spaces": {
+    "path": "./pubnub-spaces",
+    "name": "Kotlin Spaces",
+    "main": false
+  },
+  "bom": {
+    "path": "./pubnub-kotlin-bom",
+    "name": "Kotlin SDK BOM",
+    "main": false
+  }
+}


### PR DESCRIPTION
To be able to release modules we have to have this file first on master branch. I think we need to confirm the naming