### PR TITLE
Clen 362 2

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,9 @@
 name: kotlin
-version: 7.1.0
+version: 7.2.0
 schema: 1
 scm: github.com/pubnub/kotlin
 files:
-  - build/libs/pubnub-kotlin-7.1.0-all.jar
+  - build/libs/pubnub-kotlin-7.2.0-all.jar
 sdks:
   - 
       type: library
@@ -23,8 +23,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: GitHub
-              package-name: pubnub-kotlin-7.1.0
-              location: https://github.com/pubnub/kotlin/releases/download/v7.1.0/pubnub-kotlin-7.1.0-all.jar
+              package-name: pubnub-kotlin-7.2.0
+              location: https://github.com/pubnub/kotlin/releases/download/v7.2.0/pubnub-kotlin-7.2.0-all.jar
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -135,8 +135,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: maven
-              package-name: pubnub-kotlin-7.1.0
-              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-kotlin/7.1.0/pubnub-kotlin-7.1.0.jar
+              package-name: pubnub-kotlin-7.2.0
+              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-kotlin/7.2.0/pubnub-kotlin-7.2.0.jar
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -233,6 +233,15 @@ sdks:
                   license-url: https://github.com/stleary/JSON-java/blob/20210307/LICENSE
                   is-required: Required
 changelog:
+  - date: 2022-06-14
+    version: v7.2.0
+    changes:
+      - type: feature
+        text: "PNChannelMetadata and PNUUIDMetadata has status and type now."
+      - type: feature
+        text: "PNChannelMembership and PNMember has status now."
+      - type: bug
+        text: "It's possible to sort memberships and members by nested fields."
   - date: 2022-05-23
     version: v7.1.0
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v7.2.0
+June 14 2022
+
+#### Added
+- PNChannelMetadata and PNUUIDMetadata has status and type now.
+- PNChannelMembership and PNMember has status now.
+
+#### Fixed
+- It's possible to sort memberships and members by nested fields.
+
 ## v7.1.0
 May 23 2022
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
      <dependency>
         <groupId>com.pubnub</groupId>
         <artifactId>pubnub-gson</artifactId>
-        <version>7.1.0</version>
+        <version>7.2.0</version>
      </dependency>
      ```
 
    * for Gradle, add the following dependency in your `gradle.build`:
      ```groovy
-     implementation 'com.pubnub:pubnub-kotlin:7.1.0'
+     implementation 'com.pubnub:pubnub-kotlin:7.2.0'
      ```
 
 2. Configure your keys:

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ org.gradle.unsafe.configuration-cache=false
 
 GROUP=com.pubnub
 POM_ARTIFACT_ID=pubnub-kotlin
-VERSION_NAME=7.1.0
+VERSION_NAME=7.2.0
 POM_PACKAGING=jar
 
 POM_NAME=PubNub Android Chat Components

--- a/pubnub-memberships/build.gradle
+++ b/pubnub-memberships/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-engine:5.8.2"
     testImplementation "io.mockk:mockk:1.11.0"
     testImplementation "org.aeonbits.owner:owner:1.0.12"
+    testImplementation "org.slf4j:slf4j-simple:1.7.36"
 }
 
 configurations {

--- a/pubnub-memberships/src/main/kotlin/com/pubnub/entities/models/consumer/membership/Membership.kt
+++ b/pubnub-memberships/src/main/kotlin/com/pubnub/entities/models/consumer/membership/Membership.kt
@@ -13,8 +13,8 @@ data class Membership(
     val user: User?,
     val space: Space?,
     val custom: Map<String, Any>?,
-    val updated: String,
-    val eTag: String,
+    val updated: String? = null,
+    val eTag: String? = null,
     val status: String?
 ) {
 

--- a/pubnub-memberships/src/main/kotlin/com/pubnub/entities/models/consumer/membership/MembershipEvent.kt
+++ b/pubnub-memberships/src/main/kotlin/com/pubnub/entities/models/consumer/membership/MembershipEvent.kt
@@ -1,0 +1,65 @@
+package com.pubnub.entities.models.consumer.membership
+
+import com.pubnub.api.models.consumer.pubsub.objects.PNDeleteMembershipEventMessage
+import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
+import com.pubnub.api.models.consumer.pubsub.objects.PNSetMembershipEventMessage
+import com.pubnub.entities.models.consumer.space.Space
+import com.pubnub.entities.models.consumer.space.SpaceId
+import com.pubnub.entities.models.consumer.user.User
+import com.pubnub.entities.models.consumer.user.UserId
+
+sealed class MembershipEvent {
+    abstract val spaceId: SpaceId
+    abstract val timetoken: Long
+}
+
+data class MembershipModified(
+    override val spaceId: SpaceId,
+    override val timetoken: Long,
+    val data: Data
+) : MembershipEvent() {
+    data class Data(
+        val space: Space,
+        val user: User,
+        val custom: Map<String, Any>?,
+        val status: String?
+    )
+}
+
+data class MembershipRemoved(
+    override val spaceId: SpaceId,
+    override val timetoken: Long,
+    val data: Data
+) : MembershipEvent() {
+    data class Data(
+        val space: Space,
+        val user: User
+    )
+}
+
+fun PNObjectEventResult.toMembershipEvent(): MembershipEvent? {
+    return when (val m = extractedMessage) {
+        is PNSetMembershipEventMessage -> {
+            MembershipModified(
+                data = MembershipModified.Data(
+                    space = Space(id = SpaceId(m.data.channel)),
+                    user = User(id = UserId(m.data.uuid)),
+                    custom = m.data.custom as? Map<String, Any>,
+                    status = m.data.status
+                ),
+                spaceId = SpaceId(channel), timetoken = timetoken ?: 0
+            )
+        }
+        is PNDeleteMembershipEventMessage -> {
+            MembershipRemoved(
+                data = MembershipRemoved.Data(
+                    space = Space(id = SpaceId(m.data.channelId)), user = User(id = UserId(m.data.uuid))
+                ),
+                spaceId = SpaceId(channel), timetoken = timetoken ?: 0
+            )
+        }
+        else -> {
+            return null
+        }
+    }
+}

--- a/pubnub-memberships/src/test/kotlin/com/pubnub/entities/MembershipExtensionKtTest.kt
+++ b/pubnub-memberships/src/test/kotlin/com/pubnub/entities/MembershipExtensionKtTest.kt
@@ -24,6 +24,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -75,7 +76,18 @@ internal class MembershipExtensionKtTest {
     @Test
     internal fun can_fetchMembershipsOfUser() {
         val pnChannelMembershipArrayResult = createPNChannelMembershipArrayResult()
-        every { pubNub.getMemberships(any(), any(), any(), any(), any(), any(), any(), any()) } returns getMembershipsEndpoint
+        every {
+            pubNub.getMemberships(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns getMembershipsEndpoint
         every { getMembershipsEndpoint.sync() } returns pnChannelMembershipArrayResult
 
         val fetchMembershipOfUserEndpoint: ExtendedRemoteAction<MembershipsResult?> =
@@ -88,7 +100,18 @@ internal class MembershipExtensionKtTest {
     @Test
     internal fun can_fetchMembershipsOfSpace() {
         val pnMemberArrayResult = createPNMemberArrayResult()
-        every { pubNub.getChannelMembers(any(), any(), any(), any(), any(), any(), any(), any()) } returns getChannelMembersEndpoint
+        every {
+            pubNub.getChannelMembers(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns getChannelMembersEndpoint
         every { getChannelMembersEndpoint.sync() } returns pnMemberArrayResult
 
         val fetchMembershipOfSpaceEndpoint: ExtendedRemoteAction<MembershipsResult?> =
@@ -101,10 +124,23 @@ internal class MembershipExtensionKtTest {
     @Test
     internal fun can_addMembershipsOfUser() {
         val pnChannelMembershipArrayResult = createPNChannelMembershipArrayResult()
-        every { pubNub.setMemberships(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns manageMembershipsEndpoint
+        every {
+            pubNub.setMemberships(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns manageMembershipsEndpoint
         every { manageMembershipsEndpoint.sync() } returns pnChannelMembershipArrayResult
 
-        val partialMembershipsWithSpace = listOf(Membership.Partial(SPACE_ID, SPACE_CUSTOM), Membership.Partial(SPACE_ID_02, SPACE_CUSTOM))
+        val partialMembershipsWithSpace =
+            listOf(Membership.Partial(SPACE_ID, SPACE_CUSTOM), Membership.Partial(SPACE_ID_02, SPACE_CUSTOM))
         val addMembershipOfUserEndpoint: ExtendedRemoteAction<MembershipsStatusResult> =
             pubNub.addMemberships(partialMembershipsWithSpace = partialMembershipsWithSpace, userId = USER_ID)
         val membershipsResult = addMembershipOfUserEndpoint.sync()
@@ -115,10 +151,23 @@ internal class MembershipExtensionKtTest {
     @Test
     internal fun can_addMembershipsOfSpace() {
         val pnMemberArrayResult = createPNMemberArrayResult()
-        every { pubNub.setChannelMembers(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns manageChannelMembersEndpoint
+        every {
+            pubNub.setChannelMembers(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns manageChannelMembersEndpoint
         every { manageChannelMembersEndpoint.sync() } returns pnMemberArrayResult
 
-        val partialMembershipsWithUser = listOf(Membership.Partial(USER_ID, USER_CUSTOM), Membership.Partial(USER_ID_02, USER_CUSTOM))
+        val partialMembershipsWithUser =
+            listOf(Membership.Partial(USER_ID, USER_CUSTOM), Membership.Partial(USER_ID_02, USER_CUSTOM))
         val addMembershipOfSpaceEndpoint: ExtendedRemoteAction<MembershipsStatusResult> =
             pubNub.addMemberships(spaceId = SPACE_ID, partialMembershipsWithUser = partialMembershipsWithUser)
         val membershipsResult = addMembershipOfSpaceEndpoint.sync()
@@ -128,8 +177,21 @@ internal class MembershipExtensionKtTest {
 
     @Test
     internal fun can_removeMembershipsOfUser() {
-        val pnChannelMembershipArrayResult = PNChannelMembershipArrayResult(status = 200, data = listOf(), totalCount = 0, prev = null, next = null)
-        every { pubNub.removeMemberships(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns manageMembershipsEndpoint
+        val pnChannelMembershipArrayResult =
+            PNChannelMembershipArrayResult(status = 200, data = listOf(), totalCount = 0, prev = null, next = null)
+        every {
+            pubNub.removeMemberships(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns manageMembershipsEndpoint
         every { manageMembershipsEndpoint.sync() } returns pnChannelMembershipArrayResult
 
         val spaceIdList = listOf(SPACE_ID, SPACE_ID_02)
@@ -142,8 +204,21 @@ internal class MembershipExtensionKtTest {
 
     @Test
     internal fun can_removeMembershipsOfSpace() {
-        val pnMemberArrayResult = PNMemberArrayResult(status = 200, data = listOf(), totalCount = 0, prev = null, next = null)
-        every { pubNub.removeChannelMembers(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns manageChannelMembersEndpoint
+        val pnMemberArrayResult =
+            PNMemberArrayResult(status = 200, data = listOf(), totalCount = 0, prev = null, next = null)
+        every {
+            pubNub.removeChannelMembers(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns manageChannelMembersEndpoint
         every { manageChannelMembersEndpoint.sync() } returns pnMemberArrayResult
 
         val userIdList = listOf(USER_ID, USER_ID_02)
@@ -157,11 +232,26 @@ internal class MembershipExtensionKtTest {
     @Test
     internal fun can_updateMembershipsOfUser() {
         val pnChannelMembershipArrayResult = createPNChannelMembershipArrayResult()
-        every { pubNub.setMemberships(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns manageMembershipsEndpoint
+        every {
+            pubNub.setMemberships(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns manageMembershipsEndpoint
         every { manageMembershipsEndpoint.sync() } returns pnChannelMembershipArrayResult
 
         val partialMembershipsWithSpaceToBeUpserted = listOf(Membership.Partial(SPACE_ID_02, SPACE_CUSTOM))
-        val updateMembershipOfUserEndpoint = pubNub.updateMemberships(partialMembershipsWithSpace = partialMembershipsWithSpaceToBeUpserted, userId = USER_ID)
+        val updateMembershipOfUserEndpoint = pubNub.updateMemberships(
+            partialMembershipsWithSpace = partialMembershipsWithSpaceToBeUpserted,
+            userId = USER_ID
+        )
         val membershipsResult = updateMembershipOfUserEndpoint.sync()
 
         assertEquals(200, membershipsResult?.status)
@@ -170,36 +260,135 @@ internal class MembershipExtensionKtTest {
     @Test
     internal fun can_updateMembershipsOfSpace() {
         val pnMemberArrayResult = createPNMemberArrayResult()
-        every { pubNub.setChannelMembers(any(), any(), any(), any(), any(), any(), any(), any(), any()) } returns manageChannelMembersEndpoint
+        every {
+            pubNub.setChannelMembers(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        } returns manageChannelMembersEndpoint
         every { manageChannelMembersEndpoint.sync() } returns pnMemberArrayResult
 
-        val partialMembershipsWithUserToBeAdded = listOf(Membership.Partial(USER_ID, USER_CUSTOM), Membership.Partial(USER_ID_02, USER_CUSTOM))
-        val updateMembershipOfSpaceEndpoint = pubNub.updateMemberships(spaceId = SPACE_ID, partialMembershipsWithUser = partialMembershipsWithUserToBeAdded)
+        val partialMembershipsWithUserToBeAdded =
+            listOf(Membership.Partial(USER_ID, USER_CUSTOM), Membership.Partial(USER_ID_02, USER_CUSTOM))
+        val updateMembershipOfSpaceEndpoint = pubNub.updateMemberships(
+            spaceId = SPACE_ID,
+            partialMembershipsWithUser = partialMembershipsWithUserToBeAdded
+        )
         val membershipsResult = updateMembershipOfSpaceEndpoint.sync()
 
         assertEquals(200, membershipsResult?.status)
     }
 
+    @Test
+    internal fun can_addListenerForMembershipEvents() {
+        pubNub.addMembershipEventsListener { }
+
+        verify { pubNub.addListener(any()) }
+    }
+
+    @Test
+    internal fun can_removeListenerForMembershipEvents() {
+        val listener = pubNub.addMembershipEventsListener { }
+        listener.dispose()
+        verify { pubNub.removeListener(any()) }
+    }
+
     private fun assertMembershipResultOfSpace(fetchMembershipsResult: MembershipsResult?) {
-        val user01 = User(id = USER_ID, name = USER_NAME, externalId = EXTERNAL_ID, profileUrl = PROFILE_URL, email = EMAIL, custom = USER_CUSTOM, updated = UPDATED, eTag = E_TAG, type = TYPE, status = STATUS)
+        val user01 = User(
+            id = USER_ID,
+            name = USER_NAME,
+            externalId = EXTERNAL_ID,
+            profileUrl = PROFILE_URL,
+            email = EMAIL,
+            custom = USER_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            type = TYPE,
+            status = STATUS
+        )
         val space01 = Space(id = SPACE_ID)
-        val user02 = User(id = USER_ID_02, name = USER_NAME_02, externalId = EXTERNAL_ID, profileUrl = PROFILE_URL, email = EMAIL, custom = USER_CUSTOM, updated = UPDATED, eTag = E_TAG, type = TYPE, status = STATUS)
+        val user02 = User(
+            id = USER_ID_02,
+            name = USER_NAME_02,
+            externalId = EXTERNAL_ID,
+            profileUrl = PROFILE_URL,
+            email = EMAIL,
+            custom = USER_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            type = TYPE,
+            status = STATUS
+        )
         val space02 = Space(id = SPACE_ID)
-        val membership01 = Membership(user = user01, space = space01, custom = MEMBERSHIP_CUSTOM, updated = UPDATED, eTag = E_TAG, status = STATUS)
-        val membership02 = Membership(user = user02, space = space02, custom = MEMBERSHIP_CUSTOM, updated = UPDATED, eTag = E_TAG, status = STATUS)
+        val membership01 = Membership(
+            user = user01,
+            space = space01,
+            custom = MEMBERSHIP_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            status = STATUS
+        )
+        val membership02 = Membership(
+            user = user02,
+            space = space02,
+            custom = MEMBERSHIP_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            status = STATUS
+        )
         val memberships = listOf(membership01, membership02)
-        val expectedFetchMembershipsResult = MembershipsResult(data = memberships, totalCount = 2, next = null, prev = null)
+        val expectedFetchMembershipsResult =
+            MembershipsResult(data = memberships, totalCount = 2, next = null, prev = null)
 
         assertEquals(expectedFetchMembershipsResult, fetchMembershipsResult)
     }
 
     private fun assertMembershipResultOfUser(fetchMembershipsResult: MembershipsResult?) {
         val user01 = User(id = USER_ID)
-        val space01 = Space(id = SPACE_ID, name = SPACE_NAME, description = SPACE_DESCRIPTION, custom = SPACE_CUSTOM, updated = UPDATED, eTag = E_TAG, type = TYPE, status = STATUS)
+        val space01 = Space(
+            id = SPACE_ID,
+            name = SPACE_NAME,
+            description = SPACE_DESCRIPTION,
+            custom = SPACE_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            type = TYPE,
+            status = STATUS
+        )
         val user02 = User(id = USER_ID)
-        val space02 = Space(id = SPACE_ID_02, name = SPACE_NAME_02, description = SPACE_DESCRIPTION, custom = SPACE_CUSTOM, updated = UPDATED, eTag = E_TAG, type = TYPE, status = STATUS)
-        val membership01 = Membership(user = user01, space = space01, custom = MEMBERSHIP_CUSTOM, updated = UPDATED, eTag = E_TAG, status = STATUS)
-        val membership02 = Membership(user = user02, space = space02, custom = MEMBERSHIP_CUSTOM_02, updated = UPDATED, eTag = E_TAG, status = STATUS)
+        val space02 = Space(
+            id = SPACE_ID_02,
+            name = SPACE_NAME_02,
+            description = SPACE_DESCRIPTION,
+            custom = SPACE_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            type = TYPE,
+            status = STATUS
+        )
+        val membership01 = Membership(
+            user = user01,
+            space = space01,
+            custom = MEMBERSHIP_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            status = STATUS
+        )
+        val membership02 = Membership(
+            user = user02,
+            space = space02,
+            custom = MEMBERSHIP_CUSTOM_02,
+            updated = UPDATED,
+            eTag = E_TAG,
+            status = STATUS
+        )
         val memberships = listOf(membership01, membership02)
         val expectedMembershipsResult = MembershipsResult(data = memberships, totalCount = 2, next = null, prev = null)
 
@@ -211,7 +400,8 @@ internal class MembershipExtensionKtTest {
             createPNMember(uuid = USER_ID, uuidName = USER_NAME),
             createPNMember(uuid = USER_ID_02, uuidName = USER_NAME_02)
         )
-        val pnMemberArrayResult = PNMemberArrayResult(status = 200, data = pnMemberList, totalCount = 2, next = null, prev = null)
+        val pnMemberArrayResult =
+            PNMemberArrayResult(status = 200, data = pnMemberList, totalCount = 2, next = null, prev = null)
         return pnMemberArrayResult
     }
 
@@ -228,7 +418,13 @@ internal class MembershipExtensionKtTest {
             type = TYPE,
             status = STATUS
         )
-        return PNMember(uuid = pnUUIDMetadata, custom = MEMBERSHIP_CUSTOM, updated = UPDATED, eTag = E_TAG, status = STATUS)
+        return PNMember(
+            uuid = pnUUIDMetadata,
+            custom = MEMBERSHIP_CUSTOM,
+            updated = UPDATED,
+            eTag = E_TAG,
+            status = STATUS
+        )
     }
 
     private fun createPNChannelMembershipArrayResult(): PNChannelMembershipArrayResult {

--- a/pubnub-spaces/src/main/kotlin/com/pubnub/entities/models/consumer/space/SpaceEvent.kt
+++ b/pubnub-spaces/src/main/kotlin/com/pubnub/entities/models/consumer/space/SpaceEvent.kt
@@ -1,0 +1,62 @@
+package com.pubnub.entities.models.consumer.space
+
+import com.pubnub.api.models.consumer.pubsub.objects.PNDeleteChannelMetadataEventMessage
+import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
+import com.pubnub.api.models.consumer.pubsub.objects.PNSetChannelMetadataEventMessage
+
+sealed class SpaceEvent {
+    abstract val spaceId: SpaceId
+    abstract val timetoken: Long
+}
+
+data class SpaceModified(
+    override val spaceId: SpaceId,
+    override val timetoken: Long,
+    val data: Data
+) : SpaceEvent() {
+    data class Data(
+        val spaceId: SpaceId,
+        val name: String?,
+        val description: String?,
+        val custom: Map<String, Any>?,
+        val status: String?,
+        val type: String?
+    )
+}
+
+data class SpaceRemoved(
+    override val spaceId: SpaceId,
+    override val timetoken: Long,
+    val data: Data
+) : SpaceEvent() {
+    data class Data(val spaceId: SpaceId)
+}
+
+fun PNObjectEventResult.toSpaceEvent(): SpaceEvent? {
+    return when (val m = extractedMessage) {
+        is PNSetChannelMetadataEventMessage -> {
+            SpaceModified(
+                spaceId = SpaceId(channel), timetoken = timetoken ?: 0,
+                data = SpaceModified.Data(
+                    spaceId = SpaceId(m.data.id),
+                    name = m.data.name,
+                    description = m.data.description,
+                    custom = m.data.custom as? Map<String, Any>,
+                    status = m.data.status,
+                    type = m.data.type
+                )
+            )
+        }
+        is PNDeleteChannelMetadataEventMessage -> {
+            SpaceRemoved(
+                spaceId = SpaceId(channel), timetoken = timetoken ?: 0,
+                data = SpaceRemoved.Data(
+                    spaceId = SpaceId(m.channel)
+                )
+            )
+        }
+        else -> {
+            return null
+        }
+    }
+}

--- a/pubnub-spaces/src/test/kotlin/com/pubnub/entities/SpaceExtensionKtTest.kt
+++ b/pubnub-spaces/src/test/kotlin/com/pubnub/entities/SpaceExtensionKtTest.kt
@@ -19,6 +19,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -138,6 +139,20 @@ class SpaceExtensionKtTest {
             ),
             spacesResult
         )
+    }
+
+    @Test
+    internal fun can_addListenerForSpaceEvents() {
+        pubNub.addSpaceEventsListener { }
+
+        verify { pubNub.addListener(any()) }
+    }
+
+    @Test
+    internal fun can_removeListenerForSpaceEvents() {
+        val listener = pubNub.addSpaceEventsListener { }
+        listener.dispose()
+        verify { pubNub.removeListener(any()) }
     }
 
     private fun createPnChannelMetadata(id: SpaceId): PNChannelMetadata {

--- a/pubnub-users/src/main/kotlin/com/pubnub/entities/models/consumer/user/UserEvent.kt
+++ b/pubnub-users/src/main/kotlin/com/pubnub/entities/models/consumer/user/UserEvent.kt
@@ -1,0 +1,68 @@
+package com.pubnub.entities.models.consumer.user
+
+import com.pubnub.api.models.consumer.pubsub.objects.PNDeleteUUIDMetadataEventMessage
+import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
+import com.pubnub.api.models.consumer.pubsub.objects.PNSetUUIDMetadataEventMessage
+
+sealed class UserEvent {
+    abstract val spaceId: String
+    abstract val timetoken: Long
+}
+
+data class UserModified(
+    override val spaceId: String,
+    override val timetoken: Long,
+    val data: Data
+) : UserEvent() {
+
+    data class Data(
+        val userId: UserId,
+        val name: String?,
+        val externalId: String?,
+        val profileUrl: String?,
+        val email: String?,
+        val custom: Map<String, Any>?,
+        val status: String?,
+        val type: String?
+    )
+}
+
+data class UserRemoved(
+    override val spaceId: String,
+    override val timetoken: Long,
+    val data: Data
+) : UserEvent() {
+    data class Data(val userId: UserId)
+}
+
+fun PNObjectEventResult.toUserEvent(): UserEvent? {
+    return when (val m = extractedMessage) {
+        is PNSetUUIDMetadataEventMessage -> {
+            UserModified(
+                spaceId = channel,
+                timetoken = timetoken ?: 0,
+                data = UserModified.Data(
+                    userId = UserId(m.data.id),
+                    name = m.data.name,
+                    profileUrl = m.data.profileUrl,
+                    email = m.data.email,
+                    status = m.data.status,
+                    type = m.data.type,
+                    custom = m.data.custom as? Map<String, Any>,
+                    externalId = m.data.externalId
+                )
+            )
+        }
+        is PNDeleteUUIDMetadataEventMessage -> {
+            UserRemoved(
+                spaceId = channel, timetoken = timetoken ?: 0,
+                data = UserRemoved.Data(
+                    userId = UserId(m.uuid)
+                )
+            )
+        }
+        else -> {
+            return null
+        }
+    }
+}

--- a/pubnub-users/src/test/kotlin/com/pubnub/entities/UserExtensionKtTest.kt
+++ b/pubnub-users/src/test/kotlin/com/pubnub/entities/UserExtensionKtTest.kt
@@ -19,6 +19,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.spyk
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -161,6 +162,20 @@ internal class UserExtensionKtTest {
             ),
             usersResult
         )
+    }
+
+    @Test
+    internal fun can_addListenerForUserEvents() {
+        pubNub.addUserEventsListener { }
+
+        verify { pubNub.addListener(any()) }
+    }
+
+    @Test
+    internal fun can_removeListenerForUserEvents() {
+        val listener = pubNub.addUserEventsListener { }
+        listener.dispose()
+        verify { pubNub.removeListener(any()) }
     }
 
     private fun createPnuuidMetadata(userId: UserId): PNUUIDMetadata {

--- a/src/integrationTest/kotlin/com/pubnub/api/integration/ObjectsIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/pubnub/api/integration/ObjectsIntegrationTest.kt
@@ -4,9 +4,10 @@ import com.pubnub.api.CommonUtils.randomValue
 import com.pubnub.api.PubNub
 import com.pubnub.api.callbacks.SubscribeCallback
 import com.pubnub.api.models.consumer.PNStatus
+import com.pubnub.api.models.consumer.objects.member.PNMember
 import com.pubnub.api.models.consumer.objects.member.PNUUIDDetailsLevel
-import com.pubnub.api.models.consumer.objects.member.PNUUIDWithCustom
 import com.pubnub.api.models.consumer.objects.membership.PNChannelDetailsLevel
+import com.pubnub.api.models.consumer.objects.membership.PNChannelMembership
 import com.pubnub.api.models.consumer.objects.membership.PNChannelWithCustom
 import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
 import com.pubnub.api.subscribeToBlocking
@@ -93,7 +94,7 @@ class ObjectsIntegrationTest : BaseIntegrationTest() {
 
     @Test
     fun addGetAndRemoveMember() {
-        val uuids = listOf(PNUUIDWithCustom(uuid = testUuid))
+        val uuids = listOf(PNMember.Partial(uuidId = testUuid, custom = null, null))
 
         val setResult = pubnub.setChannelMembers(
             channel = channel,
@@ -128,9 +129,9 @@ class ObjectsIntegrationTest : BaseIntegrationTest() {
     @Test
     fun testListeningToAllObjectsEvents() {
         val countDownLatch = CountDownLatch(8)
-        val uuids = listOf(PNUUIDWithCustom(uuid = testUuid))
+        val uuids = listOf(PNMember.Partial(uuidId = testUuid, custom = null, null))
         val channels = listOf(
-            PNChannelWithCustom(channel = channel)
+            PNChannelMembership.Partial(channelId = channel)
         )
 
         pubnub.addListener(
@@ -138,6 +139,7 @@ class ObjectsIntegrationTest : BaseIntegrationTest() {
                 override fun status(pubnub: PubNub, pnStatus: PNStatus) {}
 
                 override fun objects(pubnub: PubNub, objectEvent: PNObjectEventResult) {
+                    println(objectEvent)
                     countDownLatch.countDown()
                 }
             }
@@ -152,6 +154,7 @@ class ObjectsIntegrationTest : BaseIntegrationTest() {
         pubnub.setChannelMetadata(channel = channel, name = randomValue(15)).sync()!!
         pubnub.setUUIDMetadata(name = randomValue(15)).sync()!!
 
+        pubnub.setChannelMetadata(channel = channel, description = "aaa").sync()!!
         pubnub.removeChannelMetadata(channel = channel).sync()!!
         pubnub.removeUUIDMetadata().sync()!!
         pubnub.removeChannelMembers(channel = channel, uuids = uuids.map { it.uuid }).sync()!!

--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -92,7 +92,7 @@ class PubNub(val configuration: PNConfiguration) {
 
     companion object {
         private const val TIMESTAMP_DIVIDER = 1000
-        private const val SDK_VERSION = "7.1.0"
+        private const val SDK_VERSION = "7.2.0"
         private const val MAX_SEQUENCE = 65535
 
         /**

--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -1,6 +1,7 @@
 package com.pubnub.api
 
 import com.pubnub.api.builder.PubSub
+import com.pubnub.api.callbacks.Listener
 import com.pubnub.api.callbacks.SubscribeCallback
 import com.pubnub.api.endpoints.DeleteMessages
 import com.pubnub.api.endpoints.FetchMessages
@@ -1857,7 +1858,7 @@ class PubNub(val configuration: PNConfiguration) {
      *
      * @param listener The listener to be removed.
      */
-    fun removeListener(listener: SubscribeCallback) {
+    fun removeListener(listener: Listener) {
         subscriptionManager.removeListener(listener)
     }
 

--- a/src/main/kotlin/com/pubnub/api/callbacks/SubscribeCallback.kt
+++ b/src/main/kotlin/com/pubnub/api/callbacks/SubscribeCallback.kt
@@ -10,7 +10,22 @@ import com.pubnub.api.models.consumer.pubsub.files.PNFileEventResult
 import com.pubnub.api.models.consumer.pubsub.message_actions.PNMessageActionResult
 import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
 
-abstract class SubscribeCallback {
+interface Listener
+
+interface Disposable {
+    fun dispose()
+}
+
+class DisposableListener(
+    private val pubNub: PubNub,
+    private val listener: Listener
+) : Disposable, Listener by listener {
+    override fun dispose() {
+        pubNub.removeListener(listener)
+    }
+}
+
+abstract class SubscribeCallback : Listener {
 
     /**
      * Receive status events like

--- a/src/main/kotlin/com/pubnub/api/managers/ListenerManager.kt
+++ b/src/main/kotlin/com/pubnub/api/managers/ListenerManager.kt
@@ -1,6 +1,7 @@
 package com.pubnub.api.managers
 
 import com.pubnub.api.PubNub
+import com.pubnub.api.callbacks.Listener
 import com.pubnub.api.callbacks.SubscribeCallback
 import com.pubnub.api.models.consumer.PNStatus
 import com.pubnub.api.models.consumer.pubsub.PNMessageResult
@@ -20,7 +21,7 @@ internal class ListenerManager(val pubnub: PubNub) {
         }
     }
 
-    fun removeListener(listener: SubscribeCallback) {
+    fun removeListener(listener: Listener) {
         synchronized(listeners) {
             listeners.remove(listener)
         }

--- a/src/main/kotlin/com/pubnub/api/managers/SubscriptionManager.kt
+++ b/src/main/kotlin/com/pubnub/api/managers/SubscriptionManager.kt
@@ -9,6 +9,7 @@ import com.pubnub.api.builder.StateOperation
 import com.pubnub.api.builder.SubscribeOperation
 import com.pubnub.api.builder.TimetokenRegionOperation
 import com.pubnub.api.builder.UnsubscribeOperation
+import com.pubnub.api.callbacks.Listener
 import com.pubnub.api.callbacks.ReconnectionCallback
 import com.pubnub.api.callbacks.SubscribeCallback
 import com.pubnub.api.endpoints.presence.Heartbeat
@@ -331,7 +332,7 @@ class SubscriptionManager(val pubnub: PubNub, private val subscriptionState: Sta
         listenerManager.addListener(listener)
     }
 
-    fun removeListener(listener: SubscribeCallback) {
+    fun removeListener(listener: Listener) {
         listenerManager.removeListener(listener)
     }
 

--- a/src/main/kotlin/com/pubnub/api/models/consumer/objects/member/PNUUIDWithCustom.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/objects/member/PNUUIDWithCustom.kt
@@ -15,9 +15,9 @@ interface MemberInput {
     )
 )
 data class PNUUIDWithCustom(
-    val uuid: String,
-    val custom: Any? = null
-) {
+    override val uuid: String,
+    override val custom: Any? = null
+) : MemberInput {
     companion object {
         @Deprecated(
             message = "Use PNMember.Partial",
@@ -32,4 +32,6 @@ data class PNUUIDWithCustom(
             custom: Any? = null
         ) = PNUUIDWithCustom(uuid = uuid, custom = custom)
     }
+
+    override val status: String? = null
 }

--- a/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/objects/PNObjectEventResult.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/objects/PNObjectEventResult.kt
@@ -94,8 +94,10 @@ data class PNSetMembershipEvent(
     val channel: String,
     @JsonAdapter(UnwrapSingleField::class)
     val uuid: String,
+    val custom: Any?,
     val eTag: String,
-    val updated: String
+    val updated: String,
+    val status: String?
 )
 
 data class PNDeleteMembershipEvent(

--- a/src/test/kotlin/com/pubnub/api/legacy/PubNubTest.kt
+++ b/src/test/kotlin/com/pubnub/api/legacy/PubNubTest.kt
@@ -71,7 +71,7 @@ class PubNubTest : BaseTest() {
     fun getVersionAndTimeStamp() {
         val version = pubnub.version
         val timeStamp = pubnub.timestamp()
-        assertEquals("7.1.0", version)
+        assertEquals("7.2.0", version)
         assertTrue(timeStamp > 0)
     }
 }


### PR DESCRIPTION
fix: It's possible to sort memberships and members by nested fields

feat: PNChannelMetadata and PNUUIDMetadata has status and type now

feat: PNChannelMembership and PNMember has status now