### PR TITLE
Upgraded gson and logback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ allprojects {
 
         repositories {
             mavenCentral()
-            jcenter()
         }
 
         testSets {
@@ -90,12 +89,12 @@ dependencies {
     implementation "org.slf4j:slf4j-api:1.7.30"
 
     api 'com.squareup.okhttp3:logging-interceptor:4.9.3'
-    api 'com.google.code.gson:gson:2.8.6'
+    api 'com.google.code.gson:gson:2.9.0'
 
     allTest "com.github.tomakehurst:wiremock:2.27.2"
 
-    allTest "ch.qos.logback:logback-classic:1.2.3"
-    allTest "ch.qos.logback:logback-core:1.2.3"
+    allTest "ch.qos.logback:logback-classic:1.2.11"
+    allTest "ch.qos.logback:logback-core:1.2.11"
     allTest "org.json:json:20210307"
 
     testImplementation group: 'io.cucumber', name: 'cucumber-java', version: '6.10.4'

--- a/src/main/kotlin/com/pubnub/api/managers/MapperManager.kt
+++ b/src/main/kotlin/com/pubnub/api/managers/MapperManager.kt
@@ -58,6 +58,7 @@ class MapperManager {
             .registerTypeAdapter(Boolean::class.java, booleanAsIntAdapter)
             .registerTypeAdapter(JSONObject::class.java, JSONObjectAdapter())
             .registerTypeAdapter(JSONArray::class.java, JSONArrayAdapter())
+            .disableHtmlEscaping()
             .create()
         converterFactory = GsonConverterFactory.create(objectMapper)
     }


### PR DESCRIPTION
Reason for lib upgrade is to have non-vulnerable versions of those libs.
Deleted also jcenter() as a source for dependency as it is no longer supported.