### PR TITLE
Release v7.3.2

### DIFF
--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -1,9 +1,9 @@
 name: kotlin
-version: 7.3.1
+version: 7.3.2
 schema: 1
 scm: github.com/pubnub/kotlin
 files:
-  - build/libs/pubnub-kotlin-7.3.1-all.jar
+  - build/libs/pubnub-kotlin-7.3.2-all.jar
 sdks:
   - 
       type: library
@@ -23,8 +23,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: GitHub
-              package-name: pubnub-kotlin-7.3.1
-              location: https://github.com/pubnub/kotlin/releases/download/v7.3.1/pubnub-kotlin-7.3.1-all.jar
+              package-name: pubnub-kotlin-7.3.2
+              location: https://github.com/pubnub/kotlin/releases/download/v7.3.2/pubnub-kotlin-7.3.2-all.jar
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -135,8 +135,8 @@ sdks:
             -
               distribution-type: library
               distribution-repository: maven
-              package-name: pubnub-kotlin-7.3.1
-              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-kotlin/7.3.1/pubnub-kotlin-7.3.1.jar
+              package-name: pubnub-kotlin-7.3.2
+              location: https://repo.maven.apache.org/maven2/com/pubnub/pubnub-kotlin/7.3.2/pubnub-kotlin-7.3.2.jar
               supported-platforms:
                 supported-operating-systems:
                   Android:
@@ -233,6 +233,13 @@ sdks:
                   license-url: https://github.com/stleary/JSON-java/blob/20210307/LICENSE
                   is-required: Required
 changelog:
+  - date: 2022-07-21
+    version: v7.3.2
+    changes:
+      - type: bug
+        text: "Gson, logback."
+      - type: bug
+        text: "Removed "create" for space as a valid permission that can be assigned to token."
   - date: 2022-06-28
     version: v7.3.1
     changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v7.3.2
+July 21 2022
+
+#### Fixed
+- Gson, logback.
+- Removed "create" for space as a valid permission that can be assigned to token.
+
 ## v7.3.1
 June 28 2022
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ You will need the publish and subscribe keys to authenticate your app. Get your 
      <dependency>
         <groupId>com.pubnub</groupId>
         <artifactId>pubnub-gson</artifactId>
-        <version>7.3.1</version>
+        <version>7.3.2</version>
      </dependency>
      ```
 
    * for Gradle, add the following dependency in your `gradle.build`:
      ```groovy
-     implementation 'com.pubnub:pubnub-kotlin:7.3.1'
+     implementation 'com.pubnub:pubnub-kotlin:7.3.2'
      ```
 
 2. Configure your keys:

--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -96,7 +96,7 @@ class PubNub(val configuration: PNConfiguration) {
 
     companion object {
         private const val TIMESTAMP_DIVIDER = 1000
-        private const val SDK_VERSION = "7.3.1"
+        private const val SDK_VERSION = "7.3.2"
         private const val MAX_SEQUENCE = 65535
 
         /**

--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -96,7 +96,7 @@ class PubNub(val configuration: PNConfiguration) {
 
     companion object {
         private const val TIMESTAMP_DIVIDER = 1000
-        private const val SDK_VERSION = "7.3.2"
+        private const val SDK_VERSION = "7.3.1"
         private const val MAX_SEQUENCE = 65535
 
         /**

--- a/src/test/kotlin/com/pubnub/api/legacy/PubNubTest.kt
+++ b/src/test/kotlin/com/pubnub/api/legacy/PubNubTest.kt
@@ -71,7 +71,7 @@ class PubNubTest : BaseTest() {
     fun getVersionAndTimeStamp() {
         val version = pubnub.version
         val timeStamp = pubnub.timestamp()
-        assertEquals("7.3.1", version)
+        assertEquals("7.3.2", version)
         assertTrue(timeStamp > 0)
     }
 }


### PR DESCRIPTION
fix: Upgrade of vulnerable libs: Gson, logback

fix: Removed "create" for space as a valid permission that can be assigned to token.