### PR TITLE
Use atomic to have sequence without synchronization on Int

### DIFF
--- a/src/main/kotlin/com/pubnub/api/managers/PublishSequenceManager.kt
+++ b/src/main/kotlin/com/pubnub/api/managers/PublishSequenceManager.kt
@@ -1,17 +1,16 @@
 package com.pubnub.api.managers
 
+import java.util.concurrent.atomic.AtomicInteger
+
 internal class PublishSequenceManager(private val maxSequence: Int) {
 
-    private var nextSequence = 0
+    private val atomicSeq = AtomicInteger(1)
 
-    internal fun nextSequence(): Int {
-        synchronized(nextSequence) {
-            if (maxSequence == nextSequence) {
-                nextSequence = 1
-            } else {
-                nextSequence++
-            }
-            return nextSequence
+    internal fun nextSequence(): Int = atomicSeq.getAndUpdate {
+        if (maxSequence == it) {
+            1
+        } else {
+            it + 1
         }
     }
 }


### PR DESCRIPTION
This solves the last warning we had during the compilation time:

> w: pubnub/kotlin/src/main/kotlin/com/pubnub/api/managers/PublishSequenceManager.kt: (8, 9): Synchronizing by Int is forbidden

`getAndUpdate` is supported on Android thanks to desugaring https://developer.android.com/studio/write/java8-support-table