### PR TITLE
Add support for messageType and spaceId to fetchMessages

### DIFF
--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -552,11 +552,11 @@ class PubNub(val configuration: PNConfiguration) {
      */
     @Deprecated(
         replaceWith = ReplaceWith(
-            "fetchMessages(channels = channels, page = PNBoundedPage(start = start, end = end, limit = maximumPerChannel),includeMeta = includeMeta, includeMessageActions = includeMessageActions)",
+            "fetchMessages(channels = channels, page = PNBoundedPage(start = start, end = end, limit = maximumPerChannel),includeMeta = includeMeta, includeMessageActions = includeMessageActions, includeSpaceId = includeSpaceId, includeMessageType = includeMessageType)",
             "com.pubnub.api.models.consumer.PNBoundedPage"
         ),
         level = DeprecationLevel.ERROR,
-        message = "Use fetchMessages(String, PNBoundedPage, Boolean, Boolean) instead"
+        message = "Use fetchMessages(String, PNBoundedPage, Boolean, Boolean, Boolean, Boolean) instead"
     )
     fun fetchMessages(
         channels: List<String>,
@@ -564,12 +564,16 @@ class PubNub(val configuration: PNConfiguration) {
         start: Long? = null,
         end: Long? = null,
         includeMeta: Boolean = false,
-        includeMessageActions: Boolean = false
+        includeMessageActions: Boolean = false,
+        includeSpaceId: Boolean = false,
+        includeMessageType: Boolean = false
     ) = fetchMessages(
         channels = channels,
         page = PNBoundedPage(start = start, end = end, limit = maximumPerChannel),
         includeMeta = includeMeta,
-        includeMessageActions = includeMessageActions
+        includeMessageActions = includeMessageActions,
+        includeMessageType = includeMessageType,
+        includeSpaceId = includeSpaceId
     )
 
     /**
@@ -604,20 +608,28 @@ class PubNub(val configuration: PNConfiguration) {
      *                    Defaults to `false`.
      * @param includeMessageActions Whether to include message actions in response.
      *                              Defaults to `false`.
+     * @param includeMessageType Whether to include message type in response.
+     *                           Defaults to `false`.
+     * @param includeSpaceId Whether to include space id in response.
+     *                       Defaults to `false`.
      */
     fun fetchMessages(
         channels: List<String>,
         page: PNBoundedPage = PNBoundedPage(),
         includeUUID: Boolean = true,
         includeMeta: Boolean = false,
-        includeMessageActions: Boolean = false
+        includeMessageActions: Boolean = false,
+        includeMessageType: Boolean = true,
+        includeSpaceId: Boolean = false
     ) = FetchMessages(
         pubnub = this,
         channels = channels,
         page = page,
         includeUUID = includeUUID,
         includeMeta = includeMeta,
-        includeMessageActions = includeMessageActions
+        includeMessageActions = includeMessageActions,
+        includeMessageType = includeMessageType,
+        includeSpaceId = includeSpaceId
     )
 
     /**

--- a/src/main/kotlin/com/pubnub/api/endpoints/FetchMessages.kt
+++ b/src/main/kotlin/com/pubnub/api/endpoints/FetchMessages.kt
@@ -98,7 +98,7 @@ class FetchMessages internal constructor(
                 val newActions = if (includeMessageActions) serverMessageItem.actions ?: mapOf() else serverMessageItem.actions
                 val messageType = if (includeMessageType) {
                     serverMessageItem.userDefinedMessageType?.let { MessageType.UserDefined(it) }
-                        ?: serverMessageItem.integerMessageType.let { HistoryMessageType.of(it) }
+                        ?: serverMessageItem.pnMessageType.let { HistoryMessageType.of(it) }
                 } else {
                     null
                 }
@@ -130,11 +130,11 @@ class FetchMessages internal constructor(
         page.start?.run { queryParams["start"] = this.toString().lowercase(Locale.US) }
         page.end?.run { queryParams["end"] = this.toString().lowercase(Locale.US) }
 
-        if (includeMeta) queryParams["include_meta"] = includeMeta.toString()
+        if (includeMeta) queryParams["include_meta"] = "true"
         if (includeMessageType) {
-            queryParams[INCLUDE_MESSAGE_TYPE_QUERY_PARAM] = includeMessageType.toString()
-            queryParams[INCLUDE_TYPE_QUERY_PARAM] = includeMessageType.toString()
+            queryParams[INCLUDE_MESSAGE_TYPE_QUERY_PARAM] = "true"
+            queryParams[INCLUDE_TYPE_QUERY_PARAM] = "true"
         }
-        if (includeSpaceId) queryParams[INCLUDE_SPACE_ID_QUERY_PARAM] = includeSpaceId.toString()
+        if (includeSpaceId) queryParams[INCLUDE_SPACE_ID_QUERY_PARAM] = "true"
     }
 }

--- a/src/main/kotlin/com/pubnub/api/models/consumer/MessageType.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/MessageType.kt
@@ -3,29 +3,54 @@ package com.pubnub.api.models.consumer
 import com.pubnub.api.PubNubException
 
 fun MessageType(value: String): MessageType {
-    return UserDefined(value)
+    return MessageType.UserDefined(value)
 }
 
 sealed interface MessageType {
     companion object {
-        internal fun of(value: Int?): MessageType = when (value) {
-            null, 0 -> Message()
-            1 -> Signal()
-            2 -> Object()
-            3 -> MessageAction()
-            4 -> File()
+        internal fun of(value: Int?): PNMessageType = when (value) {
+            null, 0 -> Message
+            1 -> Signal
+            2 -> Object
+            3 -> MessageAction
+            4 -> File
             else -> throw PubNubException("Unknown message type value $value")
         }
+    }
+
+    data class UserDefined internal constructor(override val value: String) : MessageType, HistoryMessageType
+
+    object Message : PNMessageType, HistoryMessageType {
+        override val value: String = "message"
+    }
+
+    object Signal : PNMessageType {
+        override val value: String = "signal"
+    }
+
+    object File : PNMessageType, HistoryMessageType {
+        override val value: String = "file"
+    }
+
+    object Object : PNMessageType {
+        override val value: String = "object"
+    }
+
+    object MessageAction : PNMessageType {
+        override val value: String = "messageAction"
     }
 
     val value: String
 }
 
-data class UserDefined internal constructor(override val value: String) : MessageType
+sealed interface HistoryMessageType : MessageType {
+    companion object {
+        internal fun of(value: Int?): HistoryMessageType = when (value) {
+            null, 0 -> MessageType.Message
+            4 -> MessageType.File
+            else -> throw PubNubException("Unknown message type value $value")
+        }
+    }
+}
 
 sealed interface PNMessageType : MessageType
-data class Message internal constructor(override val value: String = "message") : PNMessageType
-data class Signal internal constructor(override val value: String = "signal") : PNMessageType
-data class File internal constructor(override val value: String = "file") : PNMessageType
-data class Object internal constructor(override val value: String = "object") : PNMessageType
-data class MessageAction internal constructor(override val value: String = "messageAction") : PNMessageType

--- a/src/main/kotlin/com/pubnub/api/models/consumer/history/PNFetchMessage.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/history/PNFetchMessage.kt
@@ -2,7 +2,9 @@ package com.pubnub.api.models.consumer.history
 
 import com.google.gson.JsonElement
 import com.pubnub.api.PubNub
+import com.pubnub.api.SpaceId
 import com.pubnub.api.endpoints.FetchMessages
+import com.pubnub.api.models.consumer.HistoryMessageType
 import com.pubnub.api.models.consumer.PNBoundedPage
 
 /**
@@ -28,6 +30,7 @@ data class PNFetchMessagesResult(
  * The key of the map is the action type. The value is another map,
  * which key is the actual value of the message action,
  * and the key being a list of actions, ie. a list of UUIDs which have posted such a message action.
+ * @property messageType The message type associated with the item.
  *
  * @see [Action]
  */
@@ -36,7 +39,9 @@ data class PNFetchMessageItem(
     val message: JsonElement,
     val meta: JsonElement?,
     val timetoken: Long,
-    val actions: Map<String, Map<String, List<Action>>>? = null
+    val actions: Map<String, Map<String, List<Action>>>? = null,
+    val messageType: HistoryMessageType?,
+    val spaceId: SpaceId?,
 )
 
 /**

--- a/src/main/kotlin/com/pubnub/api/models/server/FetchMessagesEnvelope.kt
+++ b/src/main/kotlin/com/pubnub/api/models/server/FetchMessagesEnvelope.kt
@@ -1,9 +1,9 @@
 package com.pubnub.api.models.server
 
-import com.pubnub.api.models.consumer.history.PNFetchMessageItem
+import com.pubnub.api.models.server.history.ServerFetchMessageItem
 
 data class FetchMessagesEnvelope(
-    val channels: Map<String, List<PNFetchMessageItem>>,
+    val channels: Map<String, List<ServerFetchMessageItem>>,
     val more: FetchMessagesPage?
 )
 

--- a/src/main/kotlin/com/pubnub/api/models/server/SubscribeMessage.kt
+++ b/src/main/kotlin/com/pubnub/api/models/server/SubscribeMessage.kt
@@ -3,9 +3,8 @@ package com.pubnub.api.models.server
 import com.google.gson.JsonElement
 import com.google.gson.annotations.SerializedName
 import com.pubnub.api.SpaceId
-import com.pubnub.api.models.consumer.File
-import com.pubnub.api.models.consumer.Message
 import com.pubnub.api.models.consumer.MessageType
+import com.pubnub.api.models.consumer.PNMessageType
 
 data class SubscribeMessage(
     @SerializedName("a")
@@ -51,11 +50,11 @@ data class SubscribeMessage(
     internal val userMessageType: MessageType?
         get() = userMessageTypeString?.let { MessageType(it) }
 
-    internal val pnMessageType: MessageType
+    internal val pnMessageType: PNMessageType
         get() = MessageType.of(pnMessageTypeInt)
 
     internal val spaceId: SpaceId?
         get() = stringSpaceId?.let { SpaceId(it) }
 
-    fun supportsEncryption() = pnMessageType.let { it is Message || it is File }
+    fun supportsEncryption() = pnMessageType.let { it is MessageType.Message || it is MessageType.File }
 }

--- a/src/main/kotlin/com/pubnub/api/models/server/history/ServerFetchMessageItem.kt
+++ b/src/main/kotlin/com/pubnub/api/models/server/history/ServerFetchMessageItem.kt
@@ -11,7 +11,7 @@ data class ServerFetchMessageItem(
     val timetoken: Long,
     val actions: Map<String, Map<String, List<Action>>>? = null,
     @SerializedName("message_type")
-    val integerMessageType: Int? = null,
+    val pnMessageType: Int? = null,
     @SerializedName("type")
     val userDefinedMessageType: String? = null,
     val spaceId: String? = null,

--- a/src/main/kotlin/com/pubnub/api/models/server/history/ServerFetchMessageItem.kt
+++ b/src/main/kotlin/com/pubnub/api/models/server/history/ServerFetchMessageItem.kt
@@ -1,0 +1,18 @@
+package com.pubnub.api.models.server.history
+
+import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
+import com.pubnub.api.models.consumer.history.Action
+
+data class ServerFetchMessageItem(
+    val uuid: String?,
+    val message: JsonElement,
+    val meta: JsonElement?,
+    val timetoken: Long,
+    val actions: Map<String, Map<String, List<Action>>>? = null,
+    @SerializedName("message_type")
+    val integerMessageType: Int? = null,
+    @SerializedName("type")
+    val userDefinedMessageType: String? = null,
+    val spaceId: String? = null,
+)

--- a/src/main/kotlin/com/pubnub/api/workers/SubscribeMessageProcessor.kt
+++ b/src/main/kotlin/com/pubnub/api/workers/SubscribeMessageProcessor.kt
@@ -7,11 +7,7 @@ import com.pubnub.api.PNConfiguration.Companion.isValid
 import com.pubnub.api.PubNub
 import com.pubnub.api.PubNubUtil
 import com.pubnub.api.managers.DuplicationManager
-import com.pubnub.api.models.consumer.File
-import com.pubnub.api.models.consumer.Message
-import com.pubnub.api.models.consumer.MessageAction
-import com.pubnub.api.models.consumer.Object
-import com.pubnub.api.models.consumer.Signal
+import com.pubnub.api.models.consumer.MessageType
 import com.pubnub.api.models.consumer.files.PNDownloadableFile
 import com.pubnub.api.models.consumer.message_actions.PNMessageAction
 import com.pubnub.api.models.consumer.pubsub.BasePubSubResult
@@ -103,7 +99,7 @@ internal class SubscribeMessageProcessor(
             )
 
             return when (message.pnMessageType) {
-                is Message -> {
+                is MessageType.Message -> {
                     PNMessageResult(
                         basePubSubResult = result,
                         message = extractedMessage!!,
@@ -111,11 +107,11 @@ internal class SubscribeMessageProcessor(
                         messageType = message.userMessageType
                     )
                 }
-                is Signal -> {
+                is MessageType.Signal -> {
                     PNSignalResult(result, extractedMessage!!)
                 }
 
-                is Object -> {
+                is MessageType.Object -> {
                     PNObjectEventResult(
                         result,
                         pubnub.mapper.convertValue(
@@ -124,7 +120,7 @@ internal class SubscribeMessageProcessor(
                     )
                 }
 
-                is MessageAction -> {
+                is MessageType.MessageAction -> {
                     val objectPayload = pubnub.mapper.convertValue(extractedMessage, ObjectPayload::class.java)
                     val data = objectPayload.data.asJsonObject
                     if (!data.has("uuid")) {
@@ -137,7 +133,7 @@ internal class SubscribeMessageProcessor(
                     )
                 }
 
-                is File -> {
+                is MessageType.File -> {
                     val fileUploadNotification = pubnub.mapper.convertValue(
                         extractedMessage, FileUploadNotification::class.java
                     )
@@ -157,8 +153,6 @@ internal class SubscribeMessageProcessor(
                             ?: JsonNull.INSTANCE
                     )
                 }
-
-                else -> null
             }
         }
     }

--- a/src/test/kotlin/com/pubnub/api/legacy/endpoints/history/FetchMessagesEndpointTest.kt
+++ b/src/test/kotlin/com/pubnub/api/legacy/endpoints/history/FetchMessagesEndpointTest.kt
@@ -9,9 +9,15 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlMatching
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.pubnub.api.endpoints.FetchMessages
 import com.pubnub.api.legacy.BaseTest
+import com.pubnub.api.models.consumer.MessageType
 import com.pubnub.api.models.consumer.PNBoundedPage
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasEntry
+import org.hamcrest.Matchers.hasKey
+import org.hamcrest.Matchers.not
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -30,13 +36,14 @@ class FetchMessagesEndpointTest : BaseTest() {
         private const val DEFAULT_INCLUDE_MESSAGE_ACTIONS = false
     }
 
+    val channel = "mychannel"
+
     @Test
     fun testSyncSuccess() {
         stubFor(
-            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel")).willReturn(
+                aResponse().withBody(
+                    """
                             {
                               "status": 200,
                               "error": false,
@@ -63,9 +70,9 @@ class FetchMessagesEndpointTest : BaseTest() {
                                 ]
                               }
                             }
-                        """.trimIndent()
-                    )
+                    """.trimIndent()
                 )
+            )
         )
 
         val response = pubnub.fetchMessages(
@@ -90,10 +97,9 @@ class FetchMessagesEndpointTest : BaseTest() {
     @Test
     fun testSyncWithoutUUIDSuccess() {
         stubFor(
-            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel")).willReturn(
+                aResponse().withBody(
+                    """
                             {
                               "status": 200,
                               "error": false,
@@ -117,9 +123,9 @@ class FetchMessagesEndpointTest : BaseTest() {
                                 ]
                               }
                             }
-                        """.trimIndent()
-                    )
+                    """.trimIndent()
                 )
+            )
         )
 
         val response = pubnub.fetchMessages(
@@ -144,10 +150,9 @@ class FetchMessagesEndpointTest : BaseTest() {
     @Test
     fun testSyncAuthSuccess() {
         stubFor(
-            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel")).willReturn(
+                aResponse().withBody(
+                    """
                             {
                               "status": 200,
                               "error": false,
@@ -171,9 +176,9 @@ class FetchMessagesEndpointTest : BaseTest() {
                                 ]
                               }
                             }
-                        """.trimIndent()
-                    )
+                    """.trimIndent()
                 )
+            )
         )
 
         pubnub.configuration.authKey = "authKey"
@@ -201,10 +206,9 @@ class FetchMessagesEndpointTest : BaseTest() {
         pubnub.configuration.useRandomInitializationVector = false
 
         stubFor(
-            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/mychannel,my_channel")).willReturn(
+                aResponse().withBody(
+                    """
                             {
                               "status": 200,
                               "error": false,
@@ -224,9 +228,9 @@ class FetchMessagesEndpointTest : BaseTest() {
                                 ]
                               }
                             }
-                        """.trimIndent()
-                    )
+                    """.trimIndent()
                 )
+            )
         )
 
         val response = pubnub.fetchMessages(
@@ -256,7 +260,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(maximumPerChannel))
+        assertThat(result, equalTo(maximumPerChannel))
     }
 
     @Test
@@ -272,8 +276,9 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_SINGLE_CHANNEL_DEFAULT_MESSAGES))
+        assertThat(result, equalTo(EXPECTED_SINGLE_CHANNEL_DEFAULT_MESSAGES))
     }
+
     @Test
     fun forSingleChannelFetchMessagesAlwaysPassDefaultWhenMaxNotSpecified() {
         // given
@@ -287,7 +292,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_SINGLE_CHANNEL_DEFAULT_MESSAGES))
+        assertThat(result, equalTo(EXPECTED_SINGLE_CHANNEL_DEFAULT_MESSAGES))
     }
 
     @Test
@@ -303,7 +308,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_SINGLE_CHANNEL_DEFAULT_MESSAGES))
+        assertThat(result, equalTo(EXPECTED_SINGLE_CHANNEL_DEFAULT_MESSAGES))
     }
 
     @Test
@@ -319,7 +324,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(maximumPerChannel))
+        assertThat(result, equalTo(maximumPerChannel))
     }
 
     @Test
@@ -335,7 +340,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_MULTIPLE_CHANNEL_DEFAULT_MESSAGES))
+        assertThat(result, equalTo(EXPECTED_MULTIPLE_CHANNEL_DEFAULT_MESSAGES))
     }
 
     @Test
@@ -351,7 +356,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_MULTIPLE_CHANNEL_DEFAULT_MESSAGES))
+        assertThat(result, equalTo(EXPECTED_MULTIPLE_CHANNEL_DEFAULT_MESSAGES))
     }
 
     @Test
@@ -368,7 +373,7 @@ class FetchMessagesEndpointTest : BaseTest() {
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_MULTIPLE_CHANNEL_DEFAULT_MESSAGES))
+        assertThat(result, equalTo(EXPECTED_MULTIPLE_CHANNEL_DEFAULT_MESSAGES))
     }
 
     @Test
@@ -378,13 +383,11 @@ class FetchMessagesEndpointTest : BaseTest() {
 
         // when
         val result = FetchMessages.effectiveMax(
-            maximumPerChannel = maximumPerChannel,
-            includeMessageActions = true,
-            numberOfChannels = 1
+            maximumPerChannel = maximumPerChannel, includeMessageActions = true, numberOfChannels = 1
         )
 
         // then
-        assertThat(result, Matchers.equalTo(maximumPerChannel))
+        assertThat(result, equalTo(maximumPerChannel))
     }
 
     @Test
@@ -394,31 +397,180 @@ class FetchMessagesEndpointTest : BaseTest() {
 
         // when
         val result = FetchMessages.effectiveMax(
-            maximumPerChannel = maximumPerChannel,
-            includeMessageActions = true,
-            numberOfChannels = 1
+            maximumPerChannel = maximumPerChannel, includeMessageActions = true, numberOfChannels = 1
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_DEFAULT_MESSAGES_WITH_ACTIONS))
+        assertThat(result, equalTo(EXPECTED_DEFAULT_MESSAGES_WITH_ACTIONS))
     }
 
     @Test
     fun forSingleChannelFetchMessagesWithActionAlwaysPassDefaultMaxWhenMaxExceeds() {
         // given
-        val maximumPerChannel = MAX_FOR_FETCH_MESSAGES_WITH_ACTIONS +
-            randomInt(MAX_FOR_FETCH_MESSAGES_WITH_ACTIONS)
+        val maximumPerChannel = MAX_FOR_FETCH_MESSAGES_WITH_ACTIONS + randomInt(MAX_FOR_FETCH_MESSAGES_WITH_ACTIONS)
 
         // when
         val result = FetchMessages.effectiveMax(
-            maximumPerChannel = maximumPerChannel,
-            includeMessageActions = true,
-            numberOfChannels = 1
+            maximumPerChannel = maximumPerChannel, includeMessageActions = true, numberOfChannels = 1
         )
 
         // then
-        assertThat(result, Matchers.equalTo(EXPECTED_MAX_MESSAGES_WITH_ACTIONS))
+        assertThat(result, equalTo(EXPECTED_MAX_MESSAGES_WITH_ACTIONS))
+    }
+
+    @Test
+    fun testIncludeSpaceIdQueryParamIsPassedInFetchMessages() {
+        stubFor(
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/$channel")).willReturn(
+                aResponse().withBody(
+                    responseWithOneMessageForChannel(channel)
+                )
+            )
+        )
+
+        pubnub.fetchMessages(
+            channels = listOf(channel), includeSpaceId = true
+        ).sync()!!
+
+        val requests = findAll(getRequestedFor(urlMatching("/.*")))
+        assertEquals(1, requests.size)
+        assertThat(
+            requests[0].queryParams.map { (k, v) -> k to v.firstValue() }.toMap(),
+            hasEntry(FetchMessages.INCLUDE_SPACE_ID_QUERY_PARAM, "true")
+        )
+    }
+
+    @Test
+    fun testMissingIncludeSpaceIdQueryParamIsNotSet() {
+        stubFor(
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/$channel")).willReturn(
+                aResponse().withBody(
+                    responseWithOneMessageForChannel(channel)
+                )
+            )
+        )
+
+        pubnub.fetchMessages(
+            channels = listOf(channel)
+        ).sync()!!
+
+        val requests = findAll(getRequestedFor(urlMatching("/.*")))
+        assertEquals(1, requests.size)
+        assertThat(requests[0].queryParams, not(hasKey(FetchMessages.INCLUDE_SPACE_ID_QUERY_PARAM)))
+    }
+
+    @Test
+    fun testIncludeMessageTypeQueryParamIsPassedInPublish() {
+        stubFor(
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/$channel")).willReturn(
+                aResponse().withBody(
+                    responseWithOneMessageForChannel(channel)
+                )
+            )
+        )
+
+        pubnub.fetchMessages(
+            channels = listOf(channel), includeMessageType = true
+        ).sync()!!
+
+        val requests = findAll(getRequestedFor(urlMatching("/.*")))
+        assertEquals(1, requests.size)
+        assertThat(
+            requests[0].queryParams.map { (k, v) -> k to v.firstValue() }.toMap(),
+            allOf(
+                hasEntry(FetchMessages.INCLUDE_MESSAGE_TYPE_QUERY_PARAM, "true"),
+                hasEntry(FetchMessages.INCLUDE_TYPE_QUERY_PARAM, "true")
+            )
+        )
+    }
+
+    @Test
+    fun testMissingIncludeMessageTypeQueryParamIsSetToTrue() {
+        stubFor(
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/$channel")).willReturn(
+                aResponse().withBody(
+                    responseWithOneMessageForChannel(channel)
+                )
+            )
+        )
+
+        pubnub.fetchMessages(
+            channels = listOf(channel)
+        ).sync()!!
+
+        val requests = findAll(getRequestedFor(urlMatching("/.*")))
+        assertEquals(1, requests.size)
+        assertThat(
+            requests[0].queryParams.map { (k, v) -> k to v.firstValue() }.toMap(),
+            allOf(
+                hasEntry(FetchMessages.INCLUDE_MESSAGE_TYPE_QUERY_PARAM, "true"),
+                hasEntry(FetchMessages.INCLUDE_TYPE_QUERY_PARAM, "true")
+            )
+        )
+    }
+
+    @Test
+    fun testMessageTypesAreProperlyDeserialized() {
+        val customType = "customType"
+
+        stubFor(
+            get(urlPathEqualTo("/v3/history/sub-key/mySubscribeKey/channel/$channel")).willReturn(
+                aResponse().withBody(
+                    responseWithMessagesForChannelWithMessageType(channel, customType)
+                )
+            )
+        )
+
+        val response = pubnub.fetchMessages(
+            channels = listOf(channel), includeMessageType = true
+        ).sync()!!
+
+        assertThat(
+            response.channels.values.flatMap { items -> items.map { it.messageType } },
+            contains(MessageType(customType), MessageType.of(0))
+        )
     }
 
     private fun randomInt(max: Int): Int = nextInt(max) + 1
+
+    private fun responseWithOneMessageForChannel(channel: String): String {
+        return """{
+          "status": 200,
+          "error": false,
+          "error_message": "",
+          "channels": {
+            "$channel": [
+              {
+                "message": "thisIsMessage",
+                "timetoken": "14797423056306675"
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+    }
+
+    private fun responseWithMessagesForChannelWithMessageType(channel: String, customType: String): String {
+        return """{
+          "status": 200,
+          "error": false,
+          "error_message": "",
+          "channels": {
+            "$channel": [
+              {
+                "message": "thisIsMessage1",
+                "timetoken": "14797423056306675",
+                "message_type": 0,
+                "type": "$customType"
+              },
+              {
+                "message": "thisIsMessage2",
+                "timetoken": "14797423056306676",
+                "message_type": 0
+              }
+            ]
+          }
+        }
+        """.trimIndent()
+    }
 }


### PR DESCRIPTION
The reason for HistoryMessageType sealed interface is that users will learn from the type system what possible types we can return:

```

    fun fetchMessageItem(): PNFetchMessageItem {
        TODO()
    }

    fun example() {
       when (fetchMessageItem().messageType) { //this when is already exhaustive
           MessageType.File -> TODO()
           MessageType.Message -> TODO()
           is MessageType.UserDefined -> TODO()
           null -> TODO()
       }
    }
```