### PR TITLE
Add support for messageType and spaceId to Signal

### DIFF
--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -265,11 +265,15 @@ class PubNub(val configuration: PNConfiguration) {
      *
      * @param channel The channel which the signal will be sent to.
      * @param message The payload which will be serialized and sent.
+     * @param spaceId ID of a space to which the message should be sent to.
+     * @param messageType The type associated with the message.
      */
     fun signal(
         channel: String,
-        message: Any
-    ) = Signal(pubnub = this, channel = channel, message = message)
+        message: Any,
+        spaceId: SpaceId? = null,
+        messageType: MessageType? = null
+    ) = Signal(pubnub = this, channel = channel, message = message, spaceId = spaceId, messageType = messageType)
     //endregion
 
     //region Subscribe

--- a/src/main/kotlin/com/pubnub/api/endpoints/pubsub/Signal.kt
+++ b/src/main/kotlin/com/pubnub/api/endpoints/pubsub/Signal.kt
@@ -4,7 +4,9 @@ import com.pubnub.api.Endpoint
 import com.pubnub.api.PubNub
 import com.pubnub.api.PubNubError
 import com.pubnub.api.PubNubException
+import com.pubnub.api.SpaceId
 import com.pubnub.api.enums.PNOperationType
+import com.pubnub.api.models.consumer.MessageType
 import com.pubnub.api.models.consumer.PNPublishResult
 import retrofit2.Call
 import retrofit2.Response
@@ -15,8 +17,15 @@ import retrofit2.Response
 class Signal internal constructor(
     pubnub: PubNub,
     val channel: String,
-    val message: Any
+    val message: Any,
+    val spaceId: SpaceId? = null,
+    val messageType: MessageType? = null
 ) : Endpoint<List<Any>, PNPublishResult>(pubnub) {
+
+    companion object {
+        internal const val SPACE_ID_QUERY_PARAM = "space-id"
+        internal const val MESSAGE_TYPE_QUERY_PARAM = "type"
+    }
 
     override fun validateParams() {
         super.validateParams()
@@ -26,6 +35,11 @@ class Signal internal constructor(
     override fun getAffectedChannels() = listOf(channel)
 
     override fun doWork(queryParams: HashMap<String, String>): Call<List<Any>> {
+
+        spaceId?.run { queryParams[SPACE_ID_QUERY_PARAM] = spaceId.value }
+
+        messageType?.run { queryParams[MESSAGE_TYPE_QUERY_PARAM] = messageType.value }
+
         return pubnub.retrofitManager.signalService.signal(
             pubKey = pubnub.configuration.publishKey,
             subKey = pubnub.configuration.subscribeKey,

--- a/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/MessageResult.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/MessageResult.kt
@@ -1,10 +1,14 @@
 package com.pubnub.api.models.consumer.pubsub
 
 import com.google.gson.JsonElement
+import com.pubnub.api.SpaceId
+import com.pubnub.api.models.consumer.MessageType
 
 /**
  * @property message The actual message content
  */
 interface MessageResult : PubSubResult {
     val message: JsonElement
+    val spaceId: SpaceId?
+    val messageType: MessageType
 }

--- a/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/PNMessageResult.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/PNMessageResult.kt
@@ -11,6 +11,6 @@ import com.pubnub.api.models.consumer.MessageType
 data class PNMessageResult internal constructor(
     private val basePubSubResult: PubSubResult,
     override val message: JsonElement,
-    val spaceId: SpaceId?,
-    val messageType: MessageType?
+    override val spaceId: SpaceId?,
+    override val messageType: MessageType
 ) : MessageResult, PubSubResult by basePubSubResult

--- a/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/PNSignalResult.kt
+++ b/src/main/kotlin/com/pubnub/api/models/consumer/pubsub/PNSignalResult.kt
@@ -1,12 +1,16 @@
 package com.pubnub.api.models.consumer.pubsub
 
 import com.google.gson.JsonElement
+import com.pubnub.api.SpaceId
 import com.pubnub.api.callbacks.SubscribeCallback
+import com.pubnub.api.models.consumer.MessageType
 
 /**
  * Wrapper around a signal received in [SubscribeCallback.signal].
  */
 data class PNSignalResult internal constructor(
     private val basePubSubResult: PubSubResult,
-    override val message: JsonElement
+    override val message: JsonElement,
+    override val spaceId: SpaceId?,
+    override val messageType: MessageType
 ) : MessageResult, PubSubResult by basePubSubResult

--- a/src/main/kotlin/com/pubnub/api/models/server/SubscribeMessage.kt
+++ b/src/main/kotlin/com/pubnub/api/models/server/SubscribeMessage.kt
@@ -44,7 +44,7 @@ data class SubscribeMessage(
     private val userMessageTypeString: String?,
 
     @SerializedName("si")
-    private val stringSpaceId: String?
+    private val spaceIdString: String?
 ) {
 
     internal val userMessageType: MessageType?
@@ -54,7 +54,7 @@ data class SubscribeMessage(
         get() = MessageType.of(pnMessageTypeInt)
 
     internal val spaceId: SpaceId?
-        get() = stringSpaceId?.let { SpaceId(it) }
+        get() = spaceIdString?.let { SpaceId(it) }
 
     fun supportsEncryption() = pnMessageType.let { it is MessageType.Message || it is MessageType.File }
 }

--- a/src/main/kotlin/com/pubnub/api/workers/SubscribeMessageProcessor.kt
+++ b/src/main/kotlin/com/pubnub/api/workers/SubscribeMessageProcessor.kt
@@ -104,11 +104,17 @@ internal class SubscribeMessageProcessor(
                         basePubSubResult = result,
                         message = extractedMessage!!,
                         spaceId = message.spaceId,
-                        messageType = message.userMessageType
+                        messageType = message.userMessageType ?: message.pnMessageType
                     )
                 }
+
                 is MessageType.Signal -> {
-                    PNSignalResult(result, extractedMessage!!)
+                    PNSignalResult(
+                        basePubSubResult = result,
+                        message = extractedMessage!!,
+                        spaceId = message.spaceId,
+                        messageType = message.userMessageType ?: message.pnMessageType
+                    )
                 }
 
                 is MessageType.Object -> {


### PR DESCRIPTION
As soon as fetchMessages is merged I'll rebase it to spaceid_messagetype