### PR TITLE
Add GSON serialization behavior from Java SDK

### DIFF
--- a/src/main/kotlin/com/pubnub/api/managers/MapperManager.kt
+++ b/src/main/kotlin/com/pubnub/api/managers/MapperManager.kt
@@ -134,8 +134,16 @@ class MapperManager {
     }
 
     fun toJson(input: Any?): String {
-        return try {
-            this.objectMapper.toJson(input)
+        try {
+            return if (input is List<*> && input.javaClass.isAnonymousClass) {
+                objectMapper.toJson(input, List::class.java)
+            } else if (input is Map<*, *> && input.javaClass.isAnonymousClass) {
+                objectMapper.toJson(input, Map::class.java)
+            } else if (input is Set<*> && input.javaClass.isAnonymousClass) {
+                objectMapper.toJson(input, Set::class.java)
+            } else {
+                objectMapper.toJson(input)
+            }
         } catch (e: JsonParseException) {
             throw PubNubException(
                 pubnubError = PubNubError.JSON_ERROR,

--- a/src/test/kotlin/com/pubnub/api/managers/MapperManagerTest.kt
+++ b/src/test/kotlin/com/pubnub/api/managers/MapperManagerTest.kt
@@ -1,0 +1,69 @@
+package com.pubnub.api.managers
+
+import com.pubnub.api.PubNubException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class MapperManagerTest {
+    @Test
+    @Throws(PubNubException::class)
+    fun toJson_anonymousList() {
+        val mapperManager = MapperManager()
+        val expected = "[1,2,3]"
+        val anonList: List<Int> = object : ArrayList<Int>() {
+            init {
+                add(1)
+                add(2)
+                add(3)
+            }
+        }
+        val regularList: MutableList<Int> = ArrayList()
+        regularList.add(1)
+        regularList.add(2)
+        regularList.add(3)
+        val json1 = mapperManager.toJson(anonList)
+        val json2 = mapperManager.toJson(regularList)
+        assertEquals(expected, json1)
+        assertEquals(expected, json2)
+    }
+
+    @Test
+    @Throws(PubNubException::class)
+    fun toJson_anonymousMap() {
+        val mapperManager = MapperManager()
+        val expected = "{\"city\":\"Toronto\"}"
+        val anonMap: HashMap<String, String> = object : HashMap<String, String>() {
+            init {
+                put("city", "Toronto")
+            }
+        }
+        val regularMap = HashMap<String, String>()
+        regularMap["city"] = "Toronto"
+        val json1 = mapperManager.toJson(anonMap)
+        val json2 = mapperManager.toJson(regularMap)
+        assertEquals(expected, json1)
+        assertEquals(expected, json2)
+    }
+
+    @Test
+    @Throws(PubNubException::class)
+    fun toJson_anonymousSet() {
+        val mapperManager = MapperManager()
+        val expected = "[1,2,3]"
+        val anonSet: Set<Int> = object : HashSet<Int>() {
+            init {
+                add(1)
+                add(2)
+                add(3)
+            }
+        }
+        val regularSet: MutableSet<Int> = HashSet()
+        regularSet.add(1)
+        regularSet.add(2)
+        regularSet.add(3)
+        val json1 = mapperManager.toJson(anonSet)
+        val json2 = mapperManager.toJson(regularSet)
+        assertEquals(expected, json1)
+        assertEquals(expected, json2)
+    }
+}


### PR DESCRIPTION
fix: allow serialization of anonymous collection classes like in the PN Java SDK