### PR TITLE
SetState handling in Presence EE

### DIFF
--- a/src/integrationTest/kotlin/com/pubnub/api/integration/HeartbeatIntegrationTest.kt
+++ b/src/integrationTest/kotlin/com/pubnub/api/integration/HeartbeatIntegrationTest.kt
@@ -13,7 +13,8 @@ import org.awaitility.Durations
 import org.hamcrest.core.IsEqual
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -26,8 +27,12 @@ class HeartbeatIntegrationTest : BaseIntegrationTest() {
         expectedChannel = randomChannel()
     }
 
-    @Test
-    fun testStateWithHeartbeat() {
+    /**
+     * Please note this test doesn't actually test sending state with the Heartbeat REST call
+     */
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun testStateWithHeartbeat(enableEE: Boolean) {
         val hits = AtomicInteger()
         val expectedStatePayload = generatePayload()
 
@@ -39,6 +44,7 @@ class HeartbeatIntegrationTest : BaseIntegrationTest() {
             getBasicPnConfiguration().apply {
                 presenceTimeout = 20
                 heartbeatInterval = 4
+                enableEventEngine = enableEE
             }
         )
 

--- a/src/main/kotlin/com/pubnub/api/PNConfiguration.kt
+++ b/src/main/kotlin/com/pubnub/api/PNConfiguration.kt
@@ -238,6 +238,20 @@ open class PNConfiguration(
     var suppressLeaveEvents = false
 
     /**
+     * When `true` the SDK will resend the last channel state that was set using [PubNub.setPresenceState]
+     * for the current [userId] with every automatic heartbeat.
+     *
+     * Applies only if [heartbeatInterval] is greater than 0 and [enableEventEngine] is true.
+     *
+     * Defaults to `true`.
+     *
+     * Please note that `sendStateWithHeartbeat` doesn't apply to state that was set on channel groups.
+     * It is recommended to disable this option if you set state for channel groups using [PubNub.setPresenceState],
+     * otherwise that state may be overwritten on the next heartbeat with individual channel states.
+     */
+    var sendStateWithHeartbeat = true
+
+    /**
      * Feature to subscribe with a custom filter expression.
      */
     var filterExpression: String = ""

--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -87,6 +87,7 @@ import com.pubnub.api.models.consumer.objects.member.PNUUIDDetailsLevel
 import com.pubnub.api.models.consumer.objects.membership.ChannelMembershipInput
 import com.pubnub.api.models.consumer.objects.membership.PNChannelDetailsLevel
 import com.pubnub.api.presence.Presence
+import com.pubnub.api.presence.eventengine.data.PresenceData
 import com.pubnub.api.presence.eventengine.effect.effectprovider.HeartbeatProviderImpl
 import com.pubnub.api.presence.eventengine.effect.effectprovider.LeaveProviderImpl
 import com.pubnub.api.subscribe.Subscribe
@@ -133,6 +134,7 @@ class PubNub internal constructor(
     private val tokenParser: TokenParser = TokenParser()
     private val listenerManager = ListenerManager(this)
     internal val subscriptionManager = SubscriptionManager(this, listenerManager)
+    private val presenceData = PresenceData()
     private val subscribe = Subscribe.create(
         this,
         listenerManager,
@@ -151,7 +153,8 @@ class PubNub internal constructor(
         heartbeatNotificationOptions = configuration.heartbeatNotificationOptions,
         listenerManager = listenerManager,
         eventEngineConf = eventEnginesConf.presence,
-        sendStateWithHeartbeat = configuration.sendStateWithHeartbeat,
+        presenceData = presenceData,
+        sendStateWithHeartbeat = configuration.sendStateWithHeartbeat
     )
 
     //endregion
@@ -758,7 +761,7 @@ class PubNub internal constructor(
         channelGroups = channelGroups,
         state = state,
         uuid = uuid,
-        presence = presence,
+        presenceData = presenceData,
     )
 
     /**

--- a/src/main/kotlin/com/pubnub/api/PubNub.kt
+++ b/src/main/kotlin/com/pubnub/api/PubNub.kt
@@ -150,7 +150,8 @@ class PubNub internal constructor(
         suppressLeaveEvents = configuration.suppressLeaveEvents,
         heartbeatNotificationOptions = configuration.heartbeatNotificationOptions,
         listenerManager = listenerManager,
-        eventEngineConf = eventEnginesConf.presence
+        eventEngineConf = eventEnginesConf.presence,
+        sendStateWithHeartbeat = configuration.sendStateWithHeartbeat,
     )
 
     //endregion
@@ -732,6 +733,11 @@ class PubNub internal constructor(
      *
      * State information is supplied as a JSON object of key/value pairs.
      *
+     * If [PNConfiguration.sendStateWithHeartbeat] is `true`, the state for channels will be saved in the PubNub
+     * client and resent with every heartbeat. In that case, it's not recommended to mix setting state
+     * through channels *and* channel groups, as state set through the channel group will be overwritten
+     * after the next heartbeat.
+     *
      * @param channels Channels to set the state to.
      * @param channelGroups Channel groups to set the state to.
      * @param state The actual state object to set.
@@ -746,13 +752,13 @@ class PubNub internal constructor(
         channelGroups: List<String> = listOf(),
         state: Any,
         uuid: String = configuration.userId.value
-    ) = SetState(
+    ): SetState = SetState(
         pubnub = this,
         channels = channels,
         channelGroups = channelGroups,
         state = state,
-        uuid = uuid
-        // todo involve EE ?
+        uuid = uuid,
+        presence = presence,
     )
 
     /**

--- a/src/main/kotlin/com/pubnub/api/endpoints/presence/SetState.kt
+++ b/src/main/kotlin/com/pubnub/api/endpoints/presence/SetState.kt
@@ -10,7 +10,7 @@ import com.pubnub.api.builder.StateOperation
 import com.pubnub.api.enums.PNOperationType
 import com.pubnub.api.models.consumer.presence.PNSetStateResult
 import com.pubnub.api.models.server.Envelope
-import com.pubnub.api.presence.Presence
+import com.pubnub.api.presence.eventengine.data.PresenceData
 import com.pubnub.api.toCsv
 import retrofit2.Call
 import retrofit2.Response
@@ -24,7 +24,7 @@ class SetState internal constructor(
     val channelGroups: List<String>,
     val state: Any,
     val uuid: String = pubnub.configuration.userId.value,
-    private val presence: Presence
+    private val presenceData: PresenceData
 ) : Endpoint<Envelope<JsonElement>, PNSetStateResult>(pubnub) {
 
     override fun getAffectedChannels() = channels
@@ -40,7 +40,7 @@ class SetState internal constructor(
         if (uuid == pubnub.configuration.userId.value) {
             val stateCopy = pubnub.mapper.fromJson(pubnub.mapper.toJson(state), JsonElement::class.java)
             if (pubnub.configuration.enableEventEngine) {
-                presence.setStates(channels.associateWith { stateCopy })
+                presenceData.channelStates.putAll(channels.associateWith { stateCopy })
             } else {
                 pubnub.subscriptionManager.adaptStateBuilder(
                     StateOperation(

--- a/src/main/kotlin/com/pubnub/api/endpoints/presence/SetState.kt
+++ b/src/main/kotlin/com/pubnub/api/endpoints/presence/SetState.kt
@@ -10,10 +10,10 @@ import com.pubnub.api.builder.StateOperation
 import com.pubnub.api.enums.PNOperationType
 import com.pubnub.api.models.consumer.presence.PNSetStateResult
 import com.pubnub.api.models.server.Envelope
+import com.pubnub.api.presence.Presence
 import com.pubnub.api.toCsv
 import retrofit2.Call
 import retrofit2.Response
-import java.util.HashMap
 
 /**
  * @see [PubNub.setPresenceState]
@@ -23,7 +23,8 @@ class SetState internal constructor(
     val channels: List<String>,
     val channelGroups: List<String>,
     val state: Any,
-    val uuid: String = pubnub.configuration.userId.value
+    val uuid: String = pubnub.configuration.userId.value,
+    private val presence: Presence
 ) : Endpoint<Envelope<JsonElement>, PNSetStateResult>(pubnub) {
 
     override fun getAffectedChannels() = channels
@@ -37,13 +38,18 @@ class SetState internal constructor(
 
     override fun doWork(queryParams: HashMap<String, String>): Call<Envelope<JsonElement>> {
         if (uuid == pubnub.configuration.userId.value) {
-            pubnub.subscriptionManager.adaptStateBuilder(
-                StateOperation(
-                    state = state,
-                    channels = channels,
-                    channelGroups = channelGroups
+            val stateCopy = pubnub.mapper.fromJson(pubnub.mapper.toJson(state), JsonElement::class.java)
+            if (pubnub.configuration.enableEventEngine) {
+                presence.setStates(channels.associateWith { stateCopy })
+            } else {
+                pubnub.subscriptionManager.adaptStateBuilder(
+                    StateOperation(
+                        state = stateCopy,
+                        channels = channels,
+                        channelGroups = channelGroups
+                    )
                 )
-            )
+            }
         }
 
         addQueryParams(queryParams)

--- a/src/main/kotlin/com/pubnub/api/eventengine/EventEngine.kt
+++ b/src/main/kotlin/com/pubnub/api/eventengine/EventEngine.kt
@@ -30,7 +30,7 @@ internal class EventEngine<Ei : EffectInvocation, Ev : Event, S : State<Ei, Ev, 
     }
 
     internal fun performTransitionAndEmitEffects(event: Ev) {
-        log.trace("Curren state is: ${currentState::class.simpleName} ; ${event::class.java.name.substringAfterLast('.').substringBefore('$')} to be handled is: $event ")
+        log.trace("Current state is: ${currentState::class.simpleName} ; ${event::class.java.name.substringAfterLast('.').substringBefore('$')} to be handled is: $event ")
         val (newState, invocations) = transition(currentState, event)
         currentState = newState
         invocations.forEach { invocation -> effectSink.add(invocation) }

--- a/src/main/kotlin/com/pubnub/api/presence/Presence.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/Presence.kt
@@ -86,8 +86,6 @@ internal interface Presence {
 
     fun disconnect()
 
-    fun setStates(newChannelStates: Map<String, Any> = mapOf())
-
     fun destroy()
 }
 
@@ -105,8 +103,6 @@ internal class PresenceNoOp : Presence {
     override fun disconnect() = noAction()
 
     override fun destroy() = noAction()
-
-    override fun setStates(newChannelStates: Map<String, Any>) = noAction()
 
     private fun noAction() {
         // Presence Event Engine is not initialized so no action here
@@ -156,10 +152,6 @@ internal class EnabledPresence(
 
     override fun disconnect() {
         presenceEventEngineManager.addEventToQueue(PresenceEvent.Disconnect)
-    }
-
-    override fun setStates(newChannelStates: Map<String, Any>) {
-        presenceData.channelStates.putAll(newChannelStates)
     }
 
     override fun destroy() {

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/data/PresenceData.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/data/PresenceData.kt
@@ -1,6 +1,7 @@
 package com.pubnub.api.presence.eventengine.data
 
+import java.util.concurrent.ConcurrentHashMap
+
 internal class PresenceData {
-    internal val channels: MutableSet<String> = mutableSetOf()
-    internal val channelGroups: MutableSet<String> = mutableSetOf()
+    internal val channelStates: ConcurrentHashMap<String, Any> = ConcurrentHashMap()
 }

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/PresenceEffectFactory.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/PresenceEffectFactory.kt
@@ -32,7 +32,11 @@ internal class PresenceEffectFactory(
                 val heartbeatRemoteAction = heartbeatProvider.getHeartbeatRemoteAction(
                     effectInvocation.channels,
                     effectInvocation.channelGroups,
-                    if (sendStateWithHeartbeat) presenceData.channelStates else null
+                    if (sendStateWithHeartbeat) {
+                        presenceData.channelStates
+                    } else {
+                        null
+                    }
                 )
                 HeartbeatEffect(heartbeatRemoteAction, presenceEventSink, heartbeatNotificationOptions, statusConsumer)
             }
@@ -41,7 +45,11 @@ internal class PresenceEffectFactory(
                 val heartbeatRemoteAction = heartbeatProvider.getHeartbeatRemoteAction(
                     effectInvocation.channels,
                     effectInvocation.channelGroups,
-                    if (sendStateWithHeartbeat) presenceData.channelStates else null
+                    if (sendStateWithHeartbeat) {
+                        presenceData.channelStates
+                    } else {
+                        null
+                    }
                 )
                 DelayedHeartbeatEffect(
                     heartbeatRemoteAction,

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/PresenceEffectFactory.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/PresenceEffectFactory.kt
@@ -4,6 +4,7 @@ import com.pubnub.api.enums.PNHeartbeatNotificationOptions
 import com.pubnub.api.eventengine.Effect
 import com.pubnub.api.eventengine.EffectFactory
 import com.pubnub.api.eventengine.Sink
+import com.pubnub.api.presence.eventengine.data.PresenceData
 import com.pubnub.api.presence.eventengine.effect.effectprovider.HeartbeatProvider
 import com.pubnub.api.presence.eventengine.effect.effectprovider.LeaveProvider
 import com.pubnub.api.presence.eventengine.event.PresenceEvent
@@ -22,13 +23,16 @@ internal class PresenceEffectFactory(
     private val suppressLeaveEvents: Boolean,
     private val heartbeatNotificationOptions: PNHeartbeatNotificationOptions,
     private val statusConsumer: StatusConsumer,
+    private val presenceData: PresenceData,
+    private val sendStateWithHeartbeat: Boolean,
 ) : EffectFactory<PresenceEffectInvocation> {
     override fun create(effectInvocation: PresenceEffectInvocation): Effect? {
         return when (effectInvocation) {
             is PresenceEffectInvocation.Heartbeat -> {
                 val heartbeatRemoteAction = heartbeatProvider.getHeartbeatRemoteAction(
                     effectInvocation.channels,
-                    effectInvocation.channelGroups
+                    effectInvocation.channelGroups,
+                    if (sendStateWithHeartbeat) presenceData.channelStates else null
                 )
                 HeartbeatEffect(heartbeatRemoteAction, presenceEventSink, heartbeatNotificationOptions, statusConsumer)
             }
@@ -36,7 +40,8 @@ internal class PresenceEffectFactory(
             is PresenceEffectInvocation.DelayedHeartbeat -> {
                 val heartbeatRemoteAction = heartbeatProvider.getHeartbeatRemoteAction(
                     effectInvocation.channels,
-                    effectInvocation.channelGroups
+                    effectInvocation.channelGroups,
+                    if (sendStateWithHeartbeat) presenceData.channelStates else null
                 )
                 DelayedHeartbeatEffect(
                     heartbeatRemoteAction,

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProvider.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProvider.kt
@@ -3,5 +3,5 @@ package com.pubnub.api.presence.eventengine.effect.effectprovider
 import com.pubnub.api.endpoints.remoteaction.RemoteAction
 
 internal fun interface HeartbeatProvider {
-    fun getHeartbeatRemoteAction(channels: Set<String>, channelGroups: Set<String>): RemoteAction<Boolean>
+    fun getHeartbeatRemoteAction(channels: Set<String>, channelGroups: Set<String>, state: Any?): RemoteAction<Boolean>
 }

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProvider.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProvider.kt
@@ -3,5 +3,9 @@ package com.pubnub.api.presence.eventengine.effect.effectprovider
 import com.pubnub.api.endpoints.remoteaction.RemoteAction
 
 internal fun interface HeartbeatProvider {
-    fun getHeartbeatRemoteAction(channels: Set<String>, channelGroups: Set<String>, state: Any?): RemoteAction<Boolean>
+    fun getHeartbeatRemoteAction(
+        channels: Set<String>,
+        channelGroups: Set<String>,
+        state: Map<String, Any>?
+    ): RemoteAction<Boolean>
 }

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProviderImpl.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProviderImpl.kt
@@ -5,7 +5,18 @@ import com.pubnub.api.endpoints.presence.Heartbeat
 import com.pubnub.api.endpoints.remoteaction.RemoteAction
 
 internal class HeartbeatProviderImpl(val pubNub: PubNub) : HeartbeatProvider {
-    override fun getHeartbeatRemoteAction(channels: Set<String>, channelGroups: Set<String>, state: Any?): RemoteAction<Boolean> {
-        return Heartbeat(pubNub, channels.toList(), channelGroups.toList(), state)
+    override fun getHeartbeatRemoteAction(
+        channels: Set<String>,
+        channelGroups: Set<String>,
+        state: Map<String, Any>?
+    ): RemoteAction<Boolean> {
+        return Heartbeat(
+            pubNub,
+            channels.toList(),
+            channelGroups.toList(),
+            state?.filter {
+                it.key in channels
+            }
+        )
     }
 }

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProviderImpl.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/effect/effectprovider/HeartbeatProviderImpl.kt
@@ -5,7 +5,7 @@ import com.pubnub.api.endpoints.presence.Heartbeat
 import com.pubnub.api.endpoints.remoteaction.RemoteAction
 
 internal class HeartbeatProviderImpl(val pubNub: PubNub) : HeartbeatProvider {
-    override fun getHeartbeatRemoteAction(channels: Set<String>, channelGroups: Set<String>): RemoteAction<Boolean> {
-        return Heartbeat(pubNub, channels.toList(), channelGroups.toList())
+    override fun getHeartbeatRemoteAction(channels: Set<String>, channelGroups: Set<String>, state: Any?): RemoteAction<Boolean> {
+        return Heartbeat(pubNub, channels.toList(), channelGroups.toList(), state)
     }
 }

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/event/PresenceEvent.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/event/PresenceEvent.kt
@@ -22,7 +22,4 @@ internal sealed class PresenceEvent : Event {
     object HeartbeatSuccess : PresenceEvent()
     data class HeartbeatFailure(val reason: PubNubException) : PresenceEvent()
     data class HeartbeatGiveup(val reason: PubNubException) : PresenceEvent()
-
-    // todo how to from setPresenceState operation call Presence EE??
-    data class StateSet(val channels: Set<String>, val channelGroups: Set<String>) : PresenceEvent()
 }

--- a/src/main/kotlin/com/pubnub/api/presence/eventengine/state/PresenceState.kt
+++ b/src/main/kotlin/com/pubnub/api/presence/eventengine/state/PresenceState.kt
@@ -44,10 +44,14 @@ internal sealed class PresenceState : State<PresenceEffectInvocation, PresenceEv
                     transitionTo(Heartbeating(channels + event.channels, channelGroups + event.channelGroups))
                 }
                 is PresenceEvent.Left -> {
-                    transitionTo(Heartbeating(channels - event.channels, channelGroups - event.channelGroups), PresenceEffectInvocation.Leave(event.channels, event.channelGroups))
-                }
-                is PresenceEvent.StateSet -> {
-                    transitionTo(Heartbeating(event.channels, event.channelGroups))
+                    if ((channels - event.channels).isEmpty() && (channelGroups - event.channelGroups).isEmpty()) {
+                        transitionTo(HeartbeatInactive, PresenceEffectInvocation.Leave(channels, channelGroups))
+                    } else {
+                        transitionTo(
+                            Heartbeating(channels - event.channels, channelGroups - event.channelGroups),
+                            PresenceEffectInvocation.Leave(event.channels, event.channelGroups)
+                        )
+                    }
                 }
                 is PresenceEvent.HeartbeatSuccess -> {
                     transitionTo(HeartbeatCooldown(channels, channelGroups))
@@ -80,10 +84,14 @@ internal sealed class PresenceState : State<PresenceEffectInvocation, PresenceEv
                     transitionTo(Heartbeating(channels + event.channels, channelGroups + event.channelGroups))
                 }
                 is PresenceEvent.Left -> {
-                    transitionTo(Heartbeating(channels - event.channels, channelGroups - event.channelGroups), PresenceEffectInvocation.Leave(event.channels, event.channelGroups))
-                }
-                is PresenceEvent.StateSet -> {
-                    transitionTo(Heartbeating(event.channels, event.channelGroups))
+                    if ((channels - event.channels).isEmpty() && (channelGroups - event.channelGroups).isEmpty()) {
+                        transitionTo(HeartbeatInactive, PresenceEffectInvocation.Leave(channels, channelGroups))
+                    } else {
+                        transitionTo(
+                            Heartbeating(channels - event.channels, channelGroups - event.channelGroups),
+                            PresenceEffectInvocation.Leave(event.channels, event.channelGroups)
+                        )
+                    }
                 }
                 is PresenceEvent.HeartbeatSuccess -> {
                     transitionTo(HeartbeatCooldown(channels, channelGroups))
@@ -123,10 +131,11 @@ internal sealed class PresenceState : State<PresenceEffectInvocation, PresenceEv
                     transitionTo(HeartbeatStopped(channels + event.channels, channelGroups + event.channelGroups))
                 }
                 is PresenceEvent.Left -> {
-                    transitionTo(HeartbeatStopped(channels - event.channels, channelGroups - event.channelGroups))
-                }
-                is PresenceEvent.StateSet -> {
-                    transitionTo(HeartbeatStopped(event.channels, event.channelGroups))
+                    if ((channels - event.channels).isEmpty() && (channelGroups - event.channelGroups).isEmpty()) {
+                        transitionTo(HeartbeatInactive)
+                    } else {
+                        transitionTo(HeartbeatStopped(channels - event.channels, channelGroups - event.channelGroups))
+                    }
                 }
                 is PresenceEvent.Reconnect -> {
                     transitionTo(Heartbeating(channels, channelGroups))
@@ -155,10 +164,14 @@ internal sealed class PresenceState : State<PresenceEffectInvocation, PresenceEv
                     transitionTo(Heartbeating(channels + event.channels, channelGroups + event.channelGroups))
                 }
                 is PresenceEvent.Left -> {
-                    transitionTo(Heartbeating(channels - event.channels, channelGroups - event.channelGroups), PresenceEffectInvocation.Leave(event.channels, event.channelGroups))
-                }
-                is PresenceEvent.StateSet -> {
-                    transitionTo(Heartbeating(event.channels, event.channelGroups))
+                    if ((channels - event.channels).isEmpty() && (channelGroups - event.channelGroups).isEmpty()) {
+                        transitionTo(HeartbeatInactive, PresenceEffectInvocation.Leave(channels, channelGroups))
+                    } else {
+                        transitionTo(
+                            Heartbeating(channels - event.channels, channelGroups - event.channelGroups),
+                            PresenceEffectInvocation.Leave(event.channels, event.channelGroups)
+                        )
+                    }
                 }
                 is PresenceEvent.Reconnect -> {
                     transitionTo(Heartbeating(channels, channelGroups))
@@ -189,10 +202,14 @@ internal sealed class PresenceState : State<PresenceEffectInvocation, PresenceEv
                     transitionTo(Heartbeating(channels + event.channels, channelGroups + event.channelGroups))
                 }
                 is PresenceEvent.Left -> {
-                    transitionTo(Heartbeating(channels - event.channels, channelGroups - event.channelGroups), PresenceEffectInvocation.Leave(event.channels, event.channelGroups))
-                }
-                is PresenceEvent.StateSet -> {
-                    transitionTo(Heartbeating(event.channels, event.channelGroups))
+                    if ((channels - event.channels).isEmpty() && (channelGroups - event.channelGroups).isEmpty()) {
+                        transitionTo(HeartbeatInactive, PresenceEffectInvocation.Leave(channels, channelGroups))
+                    } else {
+                        transitionTo(
+                            Heartbeating(channels - event.channels, channelGroups - event.channelGroups),
+                            PresenceEffectInvocation.Leave(event.channels, event.channelGroups)
+                        )
+                    }
                 }
                 is PresenceEvent.TimesUp -> {
                     transitionTo(Heartbeating(channels, channelGroups))

--- a/src/test/kotlin/com/pubnub/api/legacy/endpoints/presence/StateSetEndpointEETest.kt
+++ b/src/test/kotlin/com/pubnub/api/legacy/endpoints/presence/StateSetEndpointEETest.kt
@@ -9,10 +9,8 @@ import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.google.gson.JsonObject
 import com.pubnub.api.endpoints.presence.SetState
 import com.pubnub.api.legacy.BaseTest
-import com.pubnub.api.presence.Presence
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import com.pubnub.api.presence.eventengine.data.PresenceData
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class StateSetEndpointEETest : BaseTest() {
@@ -24,8 +22,7 @@ class StateSetEndpointEETest : BaseTest() {
 
     @Test
     fun applyStateForChannelSetsPresenceData() {
-        val presence: Presence = mockk()
-        every { presence.setStates(any()) } returns Unit
+        val presenceData = PresenceData()
 
         stubFor(
             get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/testChannel/uuid/myUUID/data"))
@@ -53,17 +50,16 @@ class StateSetEndpointEETest : BaseTest() {
             channelGroups = listOf(),
             state = mapOf("age" to 20),
             pubnub = pubnub,
-            presence = presence
+            presenceData = presenceData
         ).sync()
 
-        verify {
-            presence.setStates(
-                mapOf(
-                    "testChannel" to JsonObject().apply {
-                        addProperty("age", 20)
-                    }
-                )
-            )
-        }
+        assertEquals(
+            mapOf(
+                "testChannel" to JsonObject().apply {
+                    addProperty("age", 20)
+                }
+            ),
+            presenceData.channelStates
+        )
     }
 }

--- a/src/test/kotlin/com/pubnub/api/legacy/endpoints/presence/StateSetEndpointEETest.kt
+++ b/src/test/kotlin/com/pubnub/api/legacy/endpoints/presence/StateSetEndpointEETest.kt
@@ -1,0 +1,69 @@
+package com.pubnub.api.legacy.endpoints.presence
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.matching
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.google.gson.JsonObject
+import com.pubnub.api.endpoints.presence.SetState
+import com.pubnub.api.legacy.BaseTest
+import com.pubnub.api.presence.Presence
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class StateSetEndpointEETest : BaseTest() {
+    override fun onBefore() {
+        initConfiguration()
+        config.enableEventEngine = true
+        initPubNub()
+    }
+
+    @Test
+    fun applyStateForChannelSetsPresenceData() {
+        val presence: Presence = mockk()
+        every { presence.setStates(any()) } returns Unit
+
+        stubFor(
+            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/testChannel/uuid/myUUID/data"))
+                .withQueryParam("uuid", matching("myUUID"))
+                .withQueryParam("state", equalToJson("""{"age":20}"""))
+                .willReturn(
+                    aResponse().withBody(
+                        """
+                        {
+                          "status": 200,
+                          "message": "OK",
+                          "payload": {
+                            "age": 20,
+                            "status": "online"
+                          },
+                          "service": "Presence"
+                        }
+                        """.trimIndent()
+                    )
+                )
+        )
+
+        SetState(
+            channels = listOf("testChannel"),
+            channelGroups = listOf(),
+            state = mapOf("age" to 20),
+            pubnub = pubnub,
+            presence = presence
+        ).sync()
+
+        verify {
+            presence.setStates(
+                mapOf(
+                    "testChannel" to JsonObject().apply {
+                        addProperty("age", 20)
+                    }
+                )
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/pubnub/api/presence/PresenceTest.kt
+++ b/src/test/kotlin/com/pubnub/api/presence/PresenceTest.kt
@@ -93,20 +93,6 @@ internal class PresenceTest {
     }
 
     @Test
-    fun `when setState is called PresenceData is filled with state`() {
-        // given
-        val presenceData = PresenceData()
-        val state = mapOf("aaa" to "bbb")
-        val presence = Presence.create(listenerManager = listenerManager, enableEventEngine = true, presenceData = presenceData)
-
-        // when
-        presence.setStates(mapOf(CHANNEL_01 to state))
-
-        // then
-        assertThat(presenceData.channelStates, Matchers.`is`(mapOf(CHANNEL_01 to state)))
-    }
-
-    @Test
     fun `when left is called PresenceData state is cleared for relevant channels`() {
         // given
         val presenceData = PresenceData()

--- a/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatCooldownStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatCooldownStateTest.kt
@@ -51,6 +51,25 @@ class TransitionFromHeartbeatCooldownStateTest {
     }
 
     @Test
+    fun `should transit from HEARTBEAT_COOLDOWN to INACTIVE and create CANCEL_WAIT and LEAVE invocations when there is LEFT event and no channels remain`() {
+        // when
+        val (newState, invocations) = transition(
+            PresenceState.HeartbeatCooldown(channels, channelGroups),
+            PresenceEvent.Left(channels, channelGroups)
+        )
+
+        // then
+        Assertions.assertEquals(PresenceState.HeartbeatInactive, newState)
+        Assertions.assertEquals(
+            setOf(
+                PresenceEffectInvocation.CancelWait,
+                PresenceEffectInvocation.Leave(channels, channelGroups)
+            ),
+            invocations
+        )
+    }
+
+    @Test
     fun `should transit from HEARTBEAT_COOLDOWN to HEARTBEATING and create CANCEL_WAIT, LEAVE and HEARTBEAT invocations when there is LEFT event`() {
         // given
         val channelToLeave = setOf("Channel01")

--- a/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatFailedStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatFailedStateTest.kt
@@ -47,6 +47,21 @@ class TransitionFromHeartbeatFailedStateTest {
     }
 
     @Test
+    fun `should transit from HEARTBEAT_FAILED to INACTIVE and create LEAVE invocation when there is LEFT event and no channels remain`() {
+        // when
+        val (newState, invocations) = transition(
+            PresenceState.HeartbeatFailed(channels, channelGroups, reason),
+            PresenceEvent.Left(channels, channelGroups)
+        )
+
+        // then
+        Assertions.assertEquals(PresenceState.HeartbeatInactive, newState)
+        Assertions.assertEquals(
+            setOf<PresenceEffectInvocation>(PresenceEffectInvocation.Leave(channels, channelGroups)), invocations
+        )
+    }
+
+    @Test
     fun `should transit from HEARTBEAT_FAILED to HEARTBEATING and creat HEARTBEAT invocation when there is JOINED event`() {
         // given
         val newChannels = channels + setOf("NewChannel")
@@ -63,28 +78,6 @@ class TransitionFromHeartbeatFailedStateTest {
         val heartbeating = newState as PresenceState.Heartbeating
         Assertions.assertEquals(newChannels, heartbeating.channels)
         Assertions.assertEquals(newChannelGroup, heartbeating.channelGroups)
-        Assertions.assertEquals(
-            setOf<PresenceEffectInvocation>(PresenceEffectInvocation.Heartbeat(newChannels, newChannelGroup)), invocations
-        )
-    }
-
-    @Test
-    fun `should transit from HEARTBEAT_FAILED to HEARTBEATING and creat HEARTBEAT invocation when there is SET_STATE event`() {
-        // given
-        val newChannels = setOf("NewChannel")
-        val newChannelGroup = setOf("NewChannelGroup")
-
-        // when
-        val (newState, invocations) = transition(
-            PresenceState.HeartbeatFailed(channels, channelGroups, reason),
-            PresenceEvent.StateSet(newChannels, newChannelGroup)
-        )
-
-        // then
-        Assertions.assertTrue(newState is PresenceState.Heartbeating)
-        val heartbeatingState = newState as PresenceState.Heartbeating
-        Assertions.assertEquals(newChannels, heartbeatingState.channels)
-        Assertions.assertEquals(newChannelGroup, heartbeatingState.channelGroups)
         Assertions.assertEquals(
             setOf<PresenceEffectInvocation>(PresenceEffectInvocation.Heartbeat(newChannels, newChannelGroup)), invocations
         )

--- a/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatInactiveStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatInactiveStateTest.kt
@@ -48,14 +48,4 @@ class TransitionFromHeartbeatInactiveStateTest {
         assertEquals(PresenceState.HeartbeatInactive, newState)
         assertEquals(emptySet<PresenceEffectInvocation>(), invocations)
     }
-
-    @Test
-    fun `should not make transition from INACTIVE when there is SET_STATE event`() {
-        // when
-        val (newState, invocations) = transition(PresenceState.HeartbeatInactive, PresenceEvent.StateSet(channels, channelGroups))
-
-        // then
-        assertEquals(PresenceState.HeartbeatInactive, newState)
-        assertEquals(emptySet<PresenceEffectInvocation>(), invocations)
-    }
 }

--- a/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatStoppedStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatStoppedStateTest.kt
@@ -42,6 +42,19 @@ class TransitionFromHeartbeatStoppedStateTest {
     }
 
     @Test
+    fun `should transit from HEARTBEAT_STOPPED to INACTIVE when there is LEFT event and no channels remain`() {
+        // when
+        val (newState, invocations) = transition(
+            PresenceState.HeartbeatStopped(channels, channelGroups),
+            PresenceEvent.Left(channels, channelGroups)
+        )
+
+        // then
+        assertTrue(newState is PresenceState.HeartbeatInactive)
+        assertTrue(invocations.isEmpty())
+    }
+
+    @Test
     fun `should transit from HEARTBEAT_STOPPED to HEARTBEAT_STOPPED when there is JOIN event`() {
         // given
         val newChannels = channels + setOf("NewChannel")
@@ -72,23 +85,6 @@ class TransitionFromHeartbeatStoppedStateTest {
         val heartbeatStopped = newState as PresenceState.HeartbeatStopped
         assertEquals(channels - channelToLeave, heartbeatStopped.channels)
         assertEquals(channelGroups - channelGroupToLeave, heartbeatStopped.channelGroups)
-        assertEquals(emptySet<PresenceEffectInvocation>(), invocations)
-    }
-
-    @Test
-    fun `should transit from HEARTBEAT_STOPPED to HEARTBEAT_STOPPED invocation when there is SET_STATE event`() {
-        // given
-        val newChannels = setOf("NewChannel")
-        val newChannelGroup = setOf("NewChannelGroup")
-
-        // when
-        val (newState, invocations) = transition(PresenceState.HeartbeatStopped(channels, channelGroups), PresenceEvent.StateSet(newChannels, newChannelGroup))
-
-        // then
-        assertTrue(newState is PresenceState.HeartbeatStopped)
-        val heartbeatStopped = newState as PresenceState.HeartbeatStopped
-        assertEquals(newChannels, heartbeatStopped.channels)
-        assertEquals(newChannelGroup, heartbeatStopped.channelGroups)
         assertEquals(emptySet<PresenceEffectInvocation>(), invocations)
     }
 

--- a/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatingStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/presence/eventengine/state/transition/TransitionFromHeartbeatingStateTest.kt
@@ -90,6 +90,28 @@ class TransitionFromHeartbeatingStateTest {
     }
 
     @Test
+    fun `should transit from HEARTBEATING to INACTIVE and create LEAVE and HEARTBEAT invocations when there is LEFT event and no channels remain`() {
+        // given
+        val channelToLeave = channels
+        val channelGroupToLeave = channelGroups
+
+        // when
+        val (newState, invocations) = transition(
+            PresenceState.Heartbeating(channels, channelGroups),
+            PresenceEvent.Left(channelToLeave, channelGroupToLeave)
+        )
+
+        // then
+        Assertions.assertTrue(newState is PresenceState.HeartbeatInactive)
+        Assertions.assertEquals(
+            setOf(
+                PresenceEffectInvocation.Leave(channels, channelGroups),
+            ),
+            invocations
+        )
+    }
+
+    @Test
     fun `should transit from HEARTBEATING to HEARTBEATING and create LEAVE and HEARTBEAT invocations when there is LEFT event`() {
         // given
         val channelToLeave = setOf("Channel01")
@@ -112,28 +134,6 @@ class TransitionFromHeartbeatingStateTest {
                 PresenceEffectInvocation.Heartbeat(channels - channelToLeave, channelGroups - channelGroupToLeave)
             ),
             invocations
-        )
-    }
-
-    @Test
-    fun `should transit from HEARTBEATING to HEARTBEATING and create HEARTBEAT invocations when there is SET_STATE event`() {
-        // given
-        val newChannels = setOf("NewChannel")
-        val newChannelGroup = setOf("NewChannelGroup")
-
-        // when
-        val (newState, invocations) = transition(
-            PresenceState.Heartbeating(channels, channelGroups),
-            PresenceEvent.StateSet(newChannels, newChannelGroup)
-        )
-
-        // then
-        Assertions.assertTrue(newState is PresenceState.Heartbeating)
-        val heartbeating = newState as PresenceState.Heartbeating
-        Assertions.assertEquals(newChannels, heartbeating.channels)
-        Assertions.assertEquals(newChannelGroup, heartbeating.channelGroups)
-        Assertions.assertEquals(
-            setOf(PresenceEffectInvocation.Heartbeat(newChannels, newChannelGroup)), invocations
         )
     }
 

--- a/src/test/kotlin/com/pubnub/contract/presence/eventEngine/step/PresenceEventEngineSteps.kt
+++ b/src/test/kotlin/com/pubnub/contract/presence/eventEngine/step/PresenceEventEngineSteps.kt
@@ -60,8 +60,8 @@ class PresenceEventEngineSteps(private val state: EventEngineState) {
                 // do nothing
             }
 
-            override fun presence(pubnub: PubNub, presence: PNPresenceEventResult) {
-                if (presence.event == "join" && (presence.channel == "first" || presence.channel == "second" || presence.channel == "third")) {
+            override fun presence(pubnub: PubNub, pnPresenceEventResult: PNPresenceEventResult) {
+                if (pnPresenceEventResult.event == "join" && (pnPresenceEventResult.channel == "first" || pnPresenceEventResult.channel == "second" || pnPresenceEventResult.channel == "third")) {
                     atomic.incrementAndGet()
                 }
             }


### PR DESCRIPTION
feat: automatically send state with heartbeats when `enableEventEngine` == true && `sendStateWithHeartbeat` == true