### PR TITLE
Subscribe Event Engine sends SubscriptionChanged events

### DIFF
--- a/src/integrationTest/kotlin/com/pubnub/api/integration/PubNubTest.kt
+++ b/src/integrationTest/kotlin/com/pubnub/api/integration/PubNubTest.kt
@@ -1,0 +1,138 @@
+package com.pubnub.api.integration
+
+import com.pubnub.api.PubNub
+import com.pubnub.api.callbacks.SubscribeCallback
+import com.pubnub.api.enums.PNOperationType
+import com.pubnub.api.models.consumer.PNStatus
+import com.pubnub.api.models.consumer.pubsub.PNEvent
+import com.pubnub.api.models.consumer.pubsub.PNMessageResult
+import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
+import com.pubnub.api.models.consumer.pubsub.PNSignalResult
+import com.pubnub.api.models.consumer.pubsub.files.PNFileEventResult
+import com.pubnub.api.models.consumer.pubsub.message_actions.PNMessageActionResult
+import com.pubnub.api.models.consumer.pubsub.objects.PNObjectEventResult
+import org.junit.Assert
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration
+
+class PubNubTest(private val pubNub: PubNub, private val withPresenceOverride: Boolean) : AutoCloseable {
+
+    private val messageQueue = ArrayBlockingQueue<PNEvent>(10)
+    private val statusQueue = ArrayBlockingQueue<PNStatus>(10)
+
+    private val verificationListener = object : SubscribeCallback() {
+        override fun status(pubnub: PubNub, pnStatus: PNStatus) {
+            statusQueue.put(pnStatus)
+        }
+
+        override fun message(pubnub: PubNub, pnMessageResult: PNMessageResult) {
+            messageQueue.put(pnMessageResult)
+        }
+
+        override fun signal(pubnub: PubNub, pnSignalResult: PNSignalResult) {
+            messageQueue.put(pnSignalResult)
+        }
+
+        override fun file(pubnub: PubNub, pnFileEventResult: PNFileEventResult) {
+            messageQueue.put(pnFileEventResult)
+        }
+
+        override fun messageAction(pubnub: PubNub, pnMessageActionResult: PNMessageActionResult) {
+            messageQueue.put(pnMessageActionResult)
+        }
+
+        override fun objects(pubnub: PubNub, objectEvent: PNObjectEventResult) {
+            messageQueue.put(objectEvent)
+        }
+
+        override fun presence(pubnub: PubNub, pnPresenceEventResult: PNPresenceEventResult) {
+            messageQueue.put(pnPresenceEventResult)
+        }
+    }
+
+    init {
+        pubNub.addListener(verificationListener)
+    }
+
+    fun subscribe(vararg channels: String, withPresence: Boolean = false) {
+        subscribe(channels.toSet())
+    }
+
+    fun subscribe(channels: Collection<String> = emptyList(), channelGroups: Collection<String> = emptyList(), withPresence: Boolean = false) {
+        pubNub.subscribe(channels.toList(), channelGroups.toList(), withPresence = withPresence || withPresenceOverride)
+        val status = statusQueue.take()
+        Assert.assertFalse(status.error)
+        Assert.assertEquals(PNOperationType.PNSubscribeOperation, status.operation)
+        Assert.assertTrue(status.affectedChannels.containsAll(channels))
+        Assert.assertTrue(status.affectedChannelGroups.containsAll(channelGroups))
+    }
+
+    fun unsubscribe(channels: Collection<String> = emptyList(), channelGroups: Collection<String> = emptyList()) {
+        pubNub.unsubscribe(channels.toList(), channelGroups.toList())
+        val status = statusQueue.take()
+        Assert.assertFalse(status.error)
+        Assert.assertTrue(
+            status.operation in setOf(
+                PNOperationType.PNSubscribeOperation,
+                PNOperationType.PNUnsubscribeOperation
+            )
+        )
+        if (status.operation == PNOperationType.PNSubscribeOperation) {
+            Assert.assertTrue(
+                "Subscribe list still contains some channels from unsubscribe request: ${channels.filter { it in status.affectedChannels }}",
+                channels.none { it in status.affectedChannels }
+            )
+            Assert.assertTrue(
+                "Subscribe list still contains some channels from unsubscribe request: ${channelGroups.filter { it in status.affectedChannelGroups }}",
+                channelGroups.none { it in status.affectedChannelGroups }
+            )
+        } else {
+            Assert.assertTrue(
+                "Unsubscribe list: ${status.affectedChannels} doesn't contain all requested channels: $channels",
+                status.affectedChannels.containsAll(channels)
+            )
+            Assert.assertTrue(
+                "Unsubscribe list: ${status.affectedChannelGroups} doesn't contain all requested channelGroups: $channelGroups",
+                status.affectedChannelGroups.containsAll(channelGroups)
+            )
+        }
+    }
+
+    fun nextStatus(): PNStatus = statusQueue.take()
+
+    fun nextStatus(timeout: Duration): PNStatus? {
+        return try {
+            FutureTask {
+                statusQueue.take()
+            }.get(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        } catch (e: TimeoutException) {
+            null
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : PNEvent> nextEvent(): T {
+        return messageQueue.take() as T
+    }
+
+    fun nextMessage() = nextEvent<PNMessageResult>()
+
+    fun skip(n: Int = 1) {
+        for (i in 0 until n) {
+            nextEvent<PNEvent>()
+        }
+    }
+
+    override fun close() {
+        if (pubNub.getSubscribedChannels().isNotEmpty() || pubNub.getSubscribedChannelGroups().isNotEmpty()) {
+            Thread.sleep(1000)
+        }
+        pubNub.removeListener(verificationListener)
+        Assert.assertTrue("There were ${messageQueue.size} unverified events in the test: ${messageQueue.joinToString(", ")}", messageQueue.isEmpty())
+    }
+}
+
+fun PubNub.test(withPresence: Boolean = false, action: PubNubTest.() -> Unit) = PubNubTest(this, withPresence).use(action)

--- a/src/integrationTest/kotlin/com/pubnub/api/integration/PublishIntegrationTests.kt
+++ b/src/integrationTest/kotlin/com/pubnub/api/integration/PublishIntegrationTests.kt
@@ -29,6 +29,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
+import org.junit.jupiter.api.Timeout
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -133,6 +134,26 @@ class PublishIntegrationTests : BaseIntegrationTest() {
         pubnub.subscribeToBlocking(expectedChannel)
 
         success.listen()
+    }
+
+    @org.junit.jupiter.api.Test
+    @Timeout(10, unit = TimeUnit.SECONDS)
+    fun testReceiveMessageV2() {
+        val expectedChannel = randomChannel()
+        val messagePayload = generateMessage(pubnub)
+        val observer = createPubNub()
+        pubnub.test {
+            subscribe(expectedChannel)
+            observer.publish(
+                message = messagePayload,
+                channel = expectedChannel
+            ).sync()
+
+            val pnMessageResult = nextMessage()
+            assertEquals(expectedChannel, pnMessageResult.channel)
+            assertEquals(observer.configuration.userId.value, pnMessageResult.publisher)
+            assertEquals(messagePayload, pnMessageResult.message)
+        }
     }
 
     @Test

--- a/src/integrationTest/kotlin/com/pubnub/api/integration/SubscribeIntegrationTests.kt
+++ b/src/integrationTest/kotlin/com/pubnub/api/integration/SubscribeIntegrationTests.kt
@@ -20,6 +20,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.jupiter.api.Timeout
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -299,5 +300,16 @@ class SubscribeIntegrationTests : BaseIntegrationTest() {
         })
 
         success.listen(10)
+    }
+
+    @org.junit.jupiter.api.Test
+    @Timeout(10, unit = TimeUnit.SECONDS)
+    fun `second consecutive subscribe works with new test helper`() = pubnub.test {
+        subscribe(listOf("abc"))
+        val tt = pubnub.publish("abc", "myMessage").sync()!!.timetoken
+        assertEquals(tt, nextMessage().timetoken!!)
+        subscribe(listOf("def"))
+        val tt2 = pubnub.publish("def", "myMessage").sync()!!.timetoken
+        assertEquals(tt2, nextMessage().timetoken!!)
     }
 }

--- a/src/main/kotlin/com/pubnub/api/enums/PNStatusCategory.kt
+++ b/src/main/kotlin/com/pubnub/api/enums/PNStatusCategory.kt
@@ -32,9 +32,15 @@ enum class PNStatusCategory {
     PNTimeoutCategory,
 
     /**
-     * SDK subscribed with a new mix of channels (fired every time the channel / channel group mix changed).
+     * SDK successfully connected the Subscribe loop.
      */
     PNConnectedCategory,
+
+    /**
+     * SDK subscribed with a new mix of channels (fired every time the channel / channel group mix changed) since the
+     * initial connection.
+     */
+    PNSubscriptionChanged,
 
     /**
      * SDK was able to reconnect to PubNub, i.e. the subscription loop has been reconnected.

--- a/src/main/kotlin/com/pubnub/api/subscribe/eventengine/state/SubscribeState.kt
+++ b/src/main/kotlin/com/pubnub/api/subscribe/eventengine/state/SubscribeState.kt
@@ -303,7 +303,18 @@ internal sealed class SubscribeState : State<SubscribeEffectInvocation, Subscrib
                 }
 
                 is SubscribeEvent.SubscriptionChanged -> {
-                    transitionTo(Receiving(event.channels, event.channelGroups, subscriptionCursor))
+                    transitionTo(
+                        Receiving(event.channels, event.channelGroups, subscriptionCursor),
+                        SubscribeEffectInvocation.EmitStatus(
+                            PNStatus(
+                                category = PNStatusCategory.PNSubscriptionChanged,
+                                operation = PNOperationType.PNSubscribeOperation,
+                                error = false,
+                                affectedChannels = event.channels.toList(),
+                                affectedChannelGroups = event.channelGroups.toList()
+                            )
+                        )
+                    )
                 }
 
                 is SubscribeEvent.SubscriptionRestored -> {
@@ -312,6 +323,15 @@ internal sealed class SubscribeState : State<SubscribeEffectInvocation, Subscrib
                             event.channels,
                             event.channelGroups,
                             SubscriptionCursor(event.subscriptionCursor.timetoken, subscriptionCursor.region)
+                        ),
+                        SubscribeEffectInvocation.EmitStatus(
+                            PNStatus(
+                                category = PNStatusCategory.PNSubscriptionChanged,
+                                operation = PNOperationType.PNSubscribeOperation,
+                                error = false,
+                                affectedChannels = event.channels.toList(),
+                                affectedChannelGroups = event.channelGroups.toList()
+                            )
                         )
                     )
                 }
@@ -380,7 +400,16 @@ internal sealed class SubscribeState : State<SubscribeEffectInvocation, Subscrib
 
                 is SubscribeEvent.SubscriptionChanged -> {
                     transitionTo(
-                        Receiving(event.channels, event.channelGroups, subscriptionCursor)
+                        Receiving(event.channels, event.channelGroups, subscriptionCursor),
+                        SubscribeEffectInvocation.EmitStatus(
+                            PNStatus(
+                                category = PNStatusCategory.PNSubscriptionChanged,
+                                operation = PNOperationType.PNSubscribeOperation,
+                                error = false,
+                                affectedChannels = event.channels.toList(),
+                                affectedChannelGroups = event.channelGroups.toList()
+                            )
+                        )
                     )
                 }
 
@@ -427,6 +456,15 @@ internal sealed class SubscribeState : State<SubscribeEffectInvocation, Subscrib
                             event.channels,
                             event.channelGroups,
                             SubscriptionCursor(event.subscriptionCursor.timetoken, subscriptionCursor.region)
+                        ),
+                        SubscribeEffectInvocation.EmitStatus(
+                            PNStatus(
+                                category = PNStatusCategory.PNSubscriptionChanged,
+                                operation = PNOperationType.PNSubscribeOperation,
+                                error = false,
+                                affectedChannels = event.channels.toList(),
+                                affectedChannelGroups = event.channelGroups.toList()
+                            )
                         )
                     )
                 }

--- a/src/test/kotlin/com/pubnub/api/subscribe/eventengine/worker/TransitionFromReceivingReconnectingStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/subscribe/eventengine/worker/TransitionFromReceivingReconnectingStateTest.kt
@@ -86,6 +86,7 @@ internal class TransitionFromReceivingReconnectingStateTest {
         assertEquals(
             setOf(
                 SubscribeEffectInvocation.CancelReceiveReconnect,
+                SubscribeEffectInvocation.EmitStatus(createSubscriptionChangedStatus(channels, channelGroups)),
                 SubscribeEffectInvocation.ReceiveMessages(channels, channelGroups, subscriptionCursor),
             ),
             invocations
@@ -209,6 +210,7 @@ internal class TransitionFromReceivingReconnectingStateTest {
         assertEquals(
             setOf(
                 SubscribeEffectInvocation.CancelReceiveReconnect,
+                SubscribeEffectInvocation.EmitStatus(createSubscriptionChangedStatus(channels, channelGroups)),
                 SubscribeEffectInvocation.ReceiveMessages(channels, channelGroups, expectedSubscriptionCursor),
             ),
             invocations
@@ -259,3 +261,11 @@ internal class TransitionFromReceivingReconnectingStateTest {
         return PNMessageResult(pubSubResult, message)
     }
 }
+
+internal fun createSubscriptionChangedStatus(channels: Collection<String>, channelGroups: Collection<String>) = PNStatus(
+    PNStatusCategory.PNSubscriptionChanged,
+    error = false,
+    operation = PNOperationType.PNSubscribeOperation,
+    affectedChannels = channels.toList(),
+    affectedChannelGroups = channelGroups.toList()
+)

--- a/src/test/kotlin/com/pubnub/api/subscribe/eventengine/worker/TransitionFromReceivingStateTest.kt
+++ b/src/test/kotlin/com/pubnub/api/subscribe/eventengine/worker/TransitionFromReceivingStateTest.kt
@@ -102,6 +102,7 @@ class TransitionFromReceivingStateTest {
         assertEquals(
             setOf(
                 SubscribeEffectInvocation.CancelReceiveMessages,
+                SubscribeEffectInvocation.EmitStatus(createSubscriptionChangedStatus(channels, channelGroups)),
                 SubscribeEffectInvocation.ReceiveMessages(channels, channelGroups, subscriptionCursor),
             ),
             invocations
@@ -133,6 +134,7 @@ class TransitionFromReceivingStateTest {
         assertEquals(
             setOf(
                 SubscribeEffectInvocation.CancelReceiveMessages,
+                SubscribeEffectInvocation.EmitStatus(createSubscriptionChangedStatus(channels, channelGroups)),
                 SubscribeEffectInvocation.ReceiveMessages(channels, channelGroups, expectedSubscriptionCursor),
             ),
             invocations


### PR DESCRIPTION
Plus minor additions with no behavior changes:
* Proof of concept of new, more resilient and faster integration test API
* Add failure logging to Presence Leave events
