### PR TITLE
Fixes according to swift module changes

### DIFF
--- a/build-logic/gradle-plugins/src/main/kotlin/com/pubnub/gradle/PubNubKotlinMultiplatformPlugin.kt
+++ b/build-logic/gradle-plugins/src/main/kotlin/com/pubnub/gradle/PubNubKotlinMultiplatformPlugin.kt
@@ -111,7 +111,7 @@ class PubNubKotlinMultiplatformPlugin : Plugin<Project> {
 //                        }
 //                        version = "7.1.0"
                             source = path(rootProject.file(swiftPath))
-                            moduleName = "PubNub"
+                            moduleName = "PubNubSDK"
                             extraOpts += listOf("-compiler-option", "-fmodules")
                         }
                     }

--- a/pubnub-core/pubnub-core-api/src/iosMain/kotlin/com/pubnub/api/JsonElement.ios.kt
+++ b/pubnub-core/pubnub-core-api/src/iosMain/kotlin/com/pubnub/api/JsonElement.ios.kt
@@ -2,7 +2,7 @@
 
 package com.pubnub.api
 
-import cocoapods.PubNubSwift.AnyJSONObjC
+import cocoapods.PubNubSwift.KMPAnyJSON
 import kotlinx.cinterop.ExperimentalForeignApi
 
 actual abstract class JsonElement(val value: Any?) {
@@ -43,7 +43,7 @@ class JsonElementImpl(value: Any?) : JsonElement(value)
 
 actual fun JsonElement.asString(): String? {
     return when (value) {
-        is AnyJSONObjC -> value.asString()
+        is KMPAnyJSON -> value.asString()
         is String -> value
         else -> null
     }
@@ -51,7 +51,7 @@ actual fun JsonElement.asString(): String? {
 
 actual fun JsonElement.asMap(): Map<String, JsonElement>? {
     return when (value) {
-        is AnyJSONObjC -> (value.asMap() as? Map<String, Any>)?.mapValues {
+        is KMPAnyJSON -> (value.asMap() as? Map<String, Any>)?.mapValues {
             JsonElementImpl(it.value)
         }
         is Map<*, *> -> (value as Map<String, *>)?.mapValues { JsonElementImpl(it.value) }
@@ -60,12 +60,12 @@ actual fun JsonElement.asMap(): Map<String, JsonElement>? {
 }
 
 actual fun JsonElement.isNull(): Boolean {
-    return value == null || (value as? AnyJSONObjC)?.isNull() == true
+    return value == null || (value as? KMPAnyJSON)?.isNull() == true
 }
 
 actual fun JsonElement.asList(): List<JsonElement>? {
     return when (value) {
-        is AnyJSONObjC -> value.asList()?.map {
+        is KMPAnyJSON -> value.asList()?.map {
             JsonElementImpl(it)
         }
         is List<*> -> value.map { JsonElementImpl(it) }
@@ -75,7 +75,7 @@ actual fun JsonElement.asList(): List<JsonElement>? {
 
 actual fun JsonElement.asLong(): Long? {
     return when (value) {
-        is AnyJSONObjC -> value.asInt()?.longValue
+        is KMPAnyJSON -> value.asInt()?.longValue
         is Long -> value
         is Int -> value.toLong()
         is Boolean -> if (value) {
@@ -89,7 +89,7 @@ actual fun JsonElement.asLong(): Long? {
 
 actual fun JsonElement.asBoolean(): Boolean? {
     return when (value) {
-        is AnyJSONObjC -> value.asBool()?.boolValue
+        is KMPAnyJSON -> value.asBool()?.boolValue
         is Boolean -> value
         else -> null
     }
@@ -97,7 +97,7 @@ actual fun JsonElement.asBoolean(): Boolean? {
 
 actual fun JsonElement.asDouble(): Double? {
     return when (value) {
-        is AnyJSONObjC -> value.asDouble()?.doubleValue
+        is KMPAnyJSON -> value.asDouble()?.doubleValue
         is Number -> value.toDouble()
         is Boolean -> if (value) {
             1.0
@@ -110,7 +110,7 @@ actual fun JsonElement.asDouble(): Double? {
 
 actual fun JsonElement.asNumber(): Number? {
     return when (value) {
-        is AnyJSONObjC -> value.asNumber() as? Number
+        is KMPAnyJSON -> value.asNumber() as? Number
         is Number -> value
         is Boolean -> if (value) {
             1
@@ -122,5 +122,5 @@ actual fun JsonElement.asNumber(): Number? {
 }
 
 actual fun createJsonElement(any: Any?): JsonElement {
-    return JsonElementImpl(AnyJSONObjC(any))
+    return JsonElementImpl(KMPAnyJSON(any))
 }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/PubNubImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/PubNubImpl.kt
@@ -1,8 +1,8 @@
 package com.pubnub.api
 
-import cocoapods.PubNubSwift.PubNubObjC
-import cocoapods.PubNubSwift.PubNubSubscriptionObjC
-import cocoapods.PubNubSwift.PubNubSubscriptionSetObjC
+import cocoapods.PubNubSwift.KMPPubNub
+import cocoapods.PubNubSwift.KMPSubscription
+import cocoapods.PubNubSwift.KMPSubscriptionSet
 import cocoapods.PubNubSwift.addEventListenerWithListener
 import cocoapods.PubNubSwift.addStatusListenerWithListener
 import cocoapods.PubNubSwift.channelGroupWith
@@ -143,9 +143,9 @@ import com.pubnub.kmp.Uploadable
 import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
-class PubNubImpl(private val pubNubObjC: PubNubObjC) : PubNub {
+class PubNubImpl(private val pubNubObjC: KMPPubNub) : PubNub {
     constructor(configuration: PNConfiguration) : this(
-        PubNubObjC(
+        KMPPubNub(
             user = configuration.userId.value,
             subKey = configuration.subscribeKey,
             pubKey = configuration.publishKey
@@ -833,7 +833,7 @@ class PubNubImpl(private val pubNubObjC: PubNubObjC) : PubNub {
 
     override fun subscriptionSetOf(subscriptions: Set<Subscription>): SubscriptionSet {
         return SubscriptionSetImpl(
-            PubNubSubscriptionSetObjC(subscriptions.filterIsInstance<SubscriptionImpl>().map { it.objCSubscription })
+            KMPSubscriptionSet(subscriptions.filterIsInstance<SubscriptionImpl>().map { it.objCSubscription })
         )
     }
 
@@ -842,14 +842,14 @@ class PubNubImpl(private val pubNubObjC: PubNubObjC) : PubNub {
         channelGroups: Set<String>,
         options: SubscriptionOptions
     ): SubscriptionSet {
-        val channelSubscriptions = channels.map { pubNubObjC.channelWith(it) }.map { entity -> PubNubSubscriptionObjC(entity) }
+        val channelSubscriptions = channels.map { pubNubObjC.channelWith(it) }.map { entity -> KMPSubscription(entity) }
         val channelGroupSubscriptions = channelGroups.map { pubNubObjC.channelGroupWith(it) }.map {
                 entity ->
-            PubNubSubscriptionObjC(entity)
+            KMPSubscription(entity)
         }
 
         return SubscriptionSetImpl(
-            PubNubSubscriptionSetObjC(channelGroupSubscriptions + channelSubscriptions)
+            KMPSubscriptionSet(channelGroupSubscriptions + channelSubscriptions)
         )
     }
 

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/DeleteMessages.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/DeleteMessages.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.deleteMessagesFrom
 import com.pubnub.api.models.consumer.history.PNDeleteMessagesResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface DeleteMessages : PNFuture<PNDeleteMessagesResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class DeleteMessagesImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val start: Long?,
     private val end: Long?

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/FetchMessages.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/FetchMessages.ios.kt
@@ -1,9 +1,9 @@
 package com.pubnub.api.endpoints
 
-import cocoapods.PubNubSwift.PubNubBoundedPageObjC
-import cocoapods.PubNubSwift.PubNubMessageActionObjC
-import cocoapods.PubNubSwift.PubNubMessageObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPBoundedPage
+import cocoapods.PubNubSwift.KMPMessage
+import cocoapods.PubNubSwift.KMPMessageAction
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.fetchMessagesFrom
 import com.pubnub.api.JsonElementImpl
 import com.pubnub.api.models.consumer.PNBoundedPage
@@ -26,7 +26,7 @@ actual interface FetchMessages : PNFuture<PNFetchMessagesResult>
 
 @OptIn(ExperimentalForeignApi::class)
 open class FetchMessagesImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val page: PNBoundedPage,
     private val includeUUID: Boolean,
@@ -41,7 +41,7 @@ open class FetchMessagesImpl(
             includeMeta = includeMeta,
             includeMessageActions = includeMessageActions,
             includeMessageType = includeMessageType,
-            page = PubNubBoundedPageObjC(
+            page = KMPBoundedPage(
                 start = page.start?.let { NSNumber(long = it) },
                 end = page.end?.let { NSNumber(long = it) },
                 limit = page.limit?.let { NSNumber(int = it) }
@@ -61,7 +61,7 @@ open class FetchMessagesImpl(
     }
 
     private fun mapMessages(rawValue: Map<Any?, *>?): Map<String, List<PNFetchMessageItem>> {
-        return (rawValue?.safeCast<String, List<PubNubMessageObjC>>())?.mapValues { entry ->
+        return (rawValue?.safeCast<String, List<KMPMessage>>())?.mapValues { entry ->
             entry.value.map {
                 PNFetchMessageItem(
                     uuid = it.publisher(),
@@ -77,7 +77,7 @@ open class FetchMessagesImpl(
     }
 
     private fun mapMessageActions(rawValue: List<*>): Map<String, Map<String, List<PNFetchMessageItem.Action>>>? {
-        return rawValue.filterIsInstance<PubNubMessageActionObjC>().groupBy { messageAction ->
+        return rawValue.filterIsInstance<KMPMessageAction>().groupBy { messageAction ->
             messageAction.actionType()
         }.mapValues { entry ->
             entry.value.groupBy { groupedMessageAction ->

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/MessageCounts.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/MessageCounts.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.messageCountsFor
 import com.pubnub.api.models.consumer.history.PNMessageCountResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface MessageCounts : PNFuture<PNMessageCountResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class MessageCountsImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val channelsTimetoken: List<Long>
 ) : MessageCounts {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/Time.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/Time.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.timeOnSuccess
 import com.pubnub.api.models.consumer.PNTimeResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface Time : PNFuture<PNTimeResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class TimeImpl(
-    private val pubnub: PubNubObjC
+    private val pubnub: KMPPubNub
 ) : Time {
     override fun async(callback: Consumer<Result<PNTimeResult>>) {
         pubnub.timeOnSuccess(

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/AddChannelChannelGroup.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/AddChannelChannelGroup.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.channel_groups
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.addChannelsTo
 import com.pubnub.api.models.consumer.channel_group.PNChannelGroupsAddChannelResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface AddChannelChannelGroup : PNFuture<PNChannelGroupsAddChannelResu
 
 @OptIn(ExperimentalForeignApi::class)
 class AddChannelChannelGroupImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val channelGroup: String
 ) : AddChannelChannelGroup {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/AllChannelsChannelGroup.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/AllChannelsChannelGroup.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.channel_groups
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.listChannelsFor
 import com.pubnub.api.models.consumer.channel_group.PNChannelGroupsAllChannelsResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface AllChannelsChannelGroup : PNFuture<PNChannelGroupsAllChannelsRe
 
 @OptIn(ExperimentalForeignApi::class)
 class AllChannelsChannelGroupImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channelGroup: String
 ) : AllChannelsChannelGroup {
     override fun async(callback: Consumer<Result<PNChannelGroupsAllChannelsResult>>) {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/DeleteChannelGroup.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/DeleteChannelGroup.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.channel_groups
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.deleteWithChannelGroup
 import com.pubnub.api.models.consumer.channel_group.PNChannelGroupsDeleteGroupResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface DeleteChannelGroup : PNFuture<PNChannelGroupsDeleteGroupResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class DeleteChannelGroupImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channelGroup: String
 ) : DeleteChannelGroup {
     override fun async(callback: Consumer<Result<PNChannelGroupsDeleteGroupResult>>) {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/ListAllChannelGroup.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/ListAllChannelGroup.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.channel_groups
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.listChannelGroupsOnSuccess
 import com.pubnub.api.models.consumer.channel_group.PNChannelGroupsListAllResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface ListAllChannelGroup : PNFuture<PNChannelGroupsListAllResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class ListAllChannelGroupImpl(
-    private val pubnub: PubNubObjC
+    private val pubnub: KMPPubNub
 ) : ListAllChannelGroup {
     override fun async(callback: Consumer<Result<PNChannelGroupsListAllResult>>) {
         pubnub.listChannelGroupsOnSuccess(

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/RemoveChannelChannelGroup.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/channel_groups/RemoveChannelChannelGroup.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.channel_groups
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeWithChannels
 import com.pubnub.api.models.consumer.channel_group.PNChannelGroupsRemoveChannelResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface RemoveChannelChannelGroup : PNFuture<PNChannelGroupsRemoveChann
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveChannelChannelGroupImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val channelGroup: String
 ) : RemoveChannelChannelGroup {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/DeleteFile.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/DeleteFile.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.files
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.deleteFileWithChannel
 import com.pubnub.api.models.consumer.files.PNDeleteFileResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface DeleteFile : PNFuture<PNDeleteFileResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class DeleteFileImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val fileName: String,
     private val fileId: String

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/DownloadFile.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/DownloadFile.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.files
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.downloadFileWithChannel
 import com.pubnub.api.models.consumer.files.PNDownloadFileResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -19,7 +19,7 @@ actual interface DownloadFile : PNFuture<PNDownloadFileResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class DownloadFileImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val fileName: String,
     private val fileId: String

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/GetFileUrl.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/GetFileUrl.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.files
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getFileUrlWithChannel
 import com.pubnub.api.models.consumer.files.PNFileUrlResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface GetFileUrl : PNFuture<PNFileUrlResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetFileUrlImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val fileName: String,
     private val fileId: String

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/ListFiles.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/ListFiles.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.files
 
-import cocoapods.PubNubSwift.PubNubFileObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPFile
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.listFilesWithChannel
 import com.pubnub.api.models.consumer.files.PNListFilesResult
 import com.pubnub.api.models.consumer.files.PNUploadedFile
@@ -23,7 +23,7 @@ actual interface ListFiles : PNFuture<PNListFilesResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class ListFilesImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val limit: Int?,
     private val next: PNPage.PNNext?
@@ -38,7 +38,7 @@ class ListFilesImpl(
                     count = files?.size ?: 0, // TODO: count property is not retrieved from ListFilesSuccessResponse in Swift SDK
                     next = nextPageHash?.let { PNPage.PNNext(pageHash = it) },
                     status = 200,
-                    data = files.filterAndMap { rawValue: PubNubFileObjC ->
+                    data = files.filterAndMap { rawValue: KMPFile ->
                         PNUploadedFile(
                             id = rawValue.id(),
                             name = rawValue.name(),

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/PublishFileMessage.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/PublishFileMessage.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.files
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.publishFileMessageWithChannel
 import com.pubnub.api.models.consumer.files.PNPublishFileMessageResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface PublishFileMessage : PNFuture<PNPublishFileMessageResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class PublishFileMessageImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val fileName: String,
     private val fileId: String,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/SendFile.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/files/SendFile.ios.kt
@@ -1,10 +1,10 @@
 package com.pubnub.api.endpoints.files
 
-import cocoapods.PubNubSwift.PubNubDataContentObjC
-import cocoapods.PubNubSwift.PubNubFileContentObjC
-import cocoapods.PubNubSwift.PubNubInputStreamContentObjC
-import cocoapods.PubNubSwift.PubNubObjC
-import cocoapods.PubNubSwift.PubNubUploadableObjC
+import cocoapods.PubNubSwift.KMPDataUploadContent
+import cocoapods.PubNubSwift.KMPFileUploadContent
+import cocoapods.PubNubSwift.KMPInputStreamUploadContent
+import cocoapods.PubNubSwift.KMPPubNub
+import cocoapods.PubNubSwift.KMPUploadable
 import cocoapods.PubNubSwift.sendFileWithChannel
 import com.pubnub.api.PubNubException
 import com.pubnub.api.models.consumer.files.PNBaseFile
@@ -28,7 +28,7 @@ actual interface SendFile : PNFuture<PNFileUploadResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class SendFileImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val fileName: String,
     private val inputStream: Uploadable,
@@ -62,16 +62,16 @@ class SendFileImpl(
         } ?: callback.accept(Result.failure(PubNubException("Invalid argument $inputStream")))
     }
 
-    private fun mapContent(content: Uploadable): PubNubUploadableObjC? {
+    private fun mapContent(content: Uploadable): KMPUploadable? {
         return when (content) {
-            is DataUploadContent -> return PubNubDataContentObjC(
+            is DataUploadContent -> return KMPDataUploadContent(
                 data = content.data,
                 contentType = content.contentType
             )
-            is FileUploadContent -> PubNubFileContentObjC(
+            is FileUploadContent -> KMPFileUploadContent(
                 fileURL = content.url
             )
-            is StreamUploadContent -> PubNubInputStreamContentObjC(
+            is StreamUploadContent -> KMPInputStreamUploadContent(
                 stream = content.stream,
                 contentType = content.contentType,
                 contentLength = content.contentLength.toLong()

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/message_actions/AddMessageAction.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/message_actions/AddMessageAction.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.message_actions
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.addMessageActionWithChannel
 import com.pubnub.api.models.consumer.message_actions.PNAddMessageActionResult
 import com.pubnub.api.models.consumer.message_actions.PNMessageAction
@@ -18,7 +18,7 @@ actual interface AddMessageAction : PNFuture<PNAddMessageActionResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class AddMessageActionImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val actionType: String,
     private val actionValue: String,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/message_actions/GetMessageActions.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/message_actions/GetMessageActions.ios.kt
@@ -1,8 +1,8 @@
 package com.pubnub.api.endpoints.message_actions
 
-import cocoapods.PubNubSwift.PubNubBoundedPageObjC
-import cocoapods.PubNubSwift.PubNubMessageActionObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPBoundedPage
+import cocoapods.PubNubSwift.KMPMessageAction
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getMessageActionsFrom
 import com.pubnub.api.models.consumer.PNBoundedPage
 import com.pubnub.api.models.consumer.message_actions.PNGetMessageActionsResult
@@ -24,20 +24,20 @@ actual interface GetMessageActions : PNFuture<PNGetMessageActionsResult>
 @OptIn(ExperimentalForeignApi::class)
 class GetMessageActionsImpl(
     private val channel: String,
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val page: PNBoundedPage
 ) : GetMessageActions {
     override fun async(callback: Consumer<Result<PNGetMessageActionsResult>>) {
         pubnub.getMessageActionsFrom(
             channel = channel,
-            page = PubNubBoundedPageObjC(
+            page = KMPBoundedPage(
                 start = page.start?.let { NSNumber(long = it) },
                 end = page.end?.let { NSNumber(long = it) },
                 limit = page.limit?.let { NSNumber(it) }
             ),
             onSuccess = callback.onSuccessHandler2 { messageActions, next ->
                 PNGetMessageActionsResult(
-                    actions = messageActions.filterAndMap { rawValue: PubNubMessageActionObjC -> createMessageAction(rawValue) }.toList(),
+                    actions = messageActions.filterAndMap { rawValue: KMPMessageAction -> createMessageAction(rawValue) }.toList(),
                     page = PNBoundedPage(
                         start = next?.start()?.longValue(),
                         end = next?.end()?.longValue(),
@@ -49,7 +49,7 @@ class GetMessageActionsImpl(
         )
     }
 
-    private fun createMessageAction(rawValue: PubNubMessageActionObjC): PNMessageAction {
+    private fun createMessageAction(rawValue: KMPMessageAction): PNMessageAction {
         return PNMessageAction(
             type = rawValue.actionType(),
             value = rawValue.actionValue(),

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/message_actions/RemoveMessageAction.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/message_actions/RemoveMessageAction.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.message_actions
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeMessageActionWithChannel
 import com.pubnub.api.models.consumer.message_actions.PNRemoveMessageActionResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface RemoveMessageAction : PNFuture<PNRemoveMessageActionResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveMessageActionImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val messageTimetoken: Long,
     private val actionTimetoken: Long

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/GetAllChannelMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/GetAllChannelMetadata.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.objects.channel
 
-import cocoapods.PubNubSwift.PubNubChannelMetadataObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPChannelMetadata
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getAllChannelMetadataWithLimit
 import com.pubnub.api.models.consumer.objects.PNKey
 import com.pubnub.api.models.consumer.objects.PNPage
@@ -26,7 +26,7 @@ actual interface GetAllChannelMetadata : PNFuture<PNChannelMetadataArrayResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetAllChannelMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val limit: Int?,
     private val page: PNPage?,
     private val filter: String?,
@@ -45,7 +45,7 @@ class GetAllChannelMetadataImpl(
             onSuccess = callback.onSuccessHandler3 { channels, totalCount, page ->
                 PNChannelMetadataArrayResult(
                     status = 200,
-                    data = channels.filterAndMap { rawValue: PubNubChannelMetadataObjC -> createPNChannelMetadata(rawValue) },
+                    data = channels.filterAndMap { rawValue: KMPChannelMetadata -> createPNChannelMetadata(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = page?.start()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = page?.end()?.let { hash -> PNPage.PNPrev(pageHash = hash) }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/GetChannelMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/GetChannelMetadata.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.objects.channel
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getChannelMetadataWithChannel
 import com.pubnub.api.models.consumer.objects.channel.PNChannelMetadataResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface GetChannelMetadata : PNFuture<PNChannelMetadataResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetChannelMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val includeCustom: Boolean
 ) : GetChannelMetadata {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/RemoveChannelMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/RemoveChannelMetadata.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.objects.channel
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeChannelMetadataWithChannel
 import com.pubnub.api.models.consumer.objects.PNRemoveMetadataResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -14,7 +14,7 @@ actual interface RemoveChannelMetadata : PNFuture<PNRemoveMetadataResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveChannelMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String
 ) : RemoveChannelMetadata {
     override fun async(callback: Consumer<Result<PNRemoveMetadataResult>>) {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/SetChannelMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/channel/SetChannelMetadata.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.objects.channel
 
-import cocoapods.PubNubSwift.AnyJSONObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPAnyJSON
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.setChannelMetadataWithChannel
 import com.pubnub.api.models.consumer.objects.channel.PNChannelMetadataResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -20,7 +20,7 @@ actual interface SetChannelMetadata : PNFuture<PNChannelMetadataResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class SetChannelMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val name: String?,
     private val description: String?,
@@ -34,7 +34,7 @@ class SetChannelMetadataImpl(
             channel = channel,
             name = name,
             description = description,
-            custom = AnyJSONObjC(value = custom?.value),
+            custom = KMPAnyJSON(value = custom?.value),
             includeCustom = includeCustom,
             type = type,
             status = status,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/member/GetChannelMembers.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/member/GetChannelMembers.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.objects.member
 
-import cocoapods.PubNubSwift.PubNubMembershipMetadataObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPMembershipMetadata
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getChannelMembersWithChannel
 import com.pubnub.api.models.consumer.objects.PNMemberKey
 import com.pubnub.api.models.consumer.objects.PNPage
@@ -26,7 +26,7 @@ actual interface GetChannelMembers : PNFuture<PNMemberArrayResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetChannelMembersImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val limit: Int?,
     private val page: PNPage?,
@@ -52,7 +52,7 @@ class GetChannelMembersImpl(
             onSuccess = callback.onSuccessHandler3 { memberships, totalCount, page ->
                 PNMemberArrayResult(
                     status = 200,
-                    data = memberships.filterAndMap { rawValue: PubNubMembershipMetadataObjC -> createPNMember(rawValue) },
+                    data = memberships.filterAndMap { rawValue: KMPMembershipMetadata -> createPNMember(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = page?.start()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = page?.end()?.let { hash -> PNPage.PNPrev(pageHash = hash) }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/member/ManageChannelMembers.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/member/ManageChannelMembers.ios.kt
@@ -1,9 +1,9 @@
 package com.pubnub.api.endpoints.objects.member
 
-import cocoapods.PubNubSwift.AnyJSONObjC
-import cocoapods.PubNubSwift.PubNubMembershipMetadataObjC
-import cocoapods.PubNubSwift.PubNubObjC
-import cocoapods.PubNubSwift.PubNubUUIDMetadataObjC
+import cocoapods.PubNubSwift.KMPAnyJSON
+import cocoapods.PubNubSwift.KMPMembershipMetadata
+import cocoapods.PubNubSwift.KMPPubNub
+import cocoapods.PubNubSwift.KMPUUIDMetadata
 import cocoapods.PubNubSwift.removeChannelMembersWithChannel
 import cocoapods.PubNubSwift.setChannelMembersWithChannel
 import com.pubnub.api.models.consumer.objects.PNMemberKey
@@ -30,7 +30,7 @@ actual interface ManageChannelMembers : PNFuture<PNMemberArrayResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class SetChannelMembersImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val uuids: List<MemberInput>,
     private val limit: Int?,
@@ -45,7 +45,7 @@ class SetChannelMembersImpl(
     override fun async(callback: Consumer<Result<PNMemberArrayResult>>) {
         pubnub.setChannelMembersWithChannel(
             channel = channel,
-            uuids = uuids.map { PubNubUUIDMetadataObjC(id = it.uuid, custom = AnyJSONObjC(it.custom?.value), status = it.status) },
+            uuids = uuids.map { KMPUUIDMetadata(id = it.uuid, custom = KMPAnyJSON(it.custom?.value), status = it.status) },
             limit = limit?.let { NSNumber(it) },
             page = createPubNubHashedPage(from = page),
             filter = filter,
@@ -58,7 +58,7 @@ class SetChannelMembersImpl(
             onSuccess = callback.onSuccessHandler3 { memberships, totalCount, page ->
                 PNMemberArrayResult(
                     status = 200,
-                    data = memberships.filterAndMap { rawValue: PubNubMembershipMetadataObjC -> createPNMember(rawValue) },
+                    data = memberships.filterAndMap { rawValue: KMPMembershipMetadata -> createPNMember(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = page?.start()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = page?.end()?.let { hash -> PNPage.PNPrev(pageHash = hash) }
@@ -71,7 +71,7 @@ class SetChannelMembersImpl(
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveChannelMembersImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val uuids: List<String>,
     private val limit: Int?,
@@ -99,7 +99,7 @@ class RemoveChannelMembersImpl(
             onSuccess = callback.onSuccessHandler3 { memberships, totalCount, next ->
                 PNMemberArrayResult(
                     status = 200,
-                    data = memberships.filterAndMap { rawValue: PubNubMembershipMetadataObjC -> createPNMember(rawValue) },
+                    data = memberships.filterAndMap { rawValue: KMPMembershipMetadata -> createPNMember(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = next?.end()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = next?.start()?.let { hash -> PNPage.PNPrev(pageHash = hash) }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/membership/GetMemberships.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/membership/GetMemberships.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.objects.membership
 
-import cocoapods.PubNubSwift.PubNubMembershipMetadataObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPMembershipMetadata
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getMembershipsWithUuid
 import com.pubnub.api.models.consumer.objects.PNMembershipKey
 import com.pubnub.api.models.consumer.objects.PNPage
@@ -26,7 +26,7 @@ actual interface GetMemberships : PNFuture<PNChannelMembershipArrayResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetMembershipsImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val uuid: String?,
     private val limit: Int?,
     private val page: PNPage?,
@@ -52,7 +52,7 @@ class GetMembershipsImpl(
             onSuccess = callback.onSuccessHandler3 { memberships, totalCount, page ->
                 PNChannelMembershipArrayResult(
                     status = 200,
-                    data = memberships.filterAndMap { rawValue: PubNubMembershipMetadataObjC -> createPNChannelMembership(rawValue) },
+                    data = memberships.filterAndMap { rawValue: KMPMembershipMetadata -> createPNChannelMembership(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = page?.start()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = page?.end()?.let { hash -> PNPage.PNPrev(pageHash = hash) }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/membership/ManageMemberships.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/membership/ManageMemberships.ios.kt
@@ -1,9 +1,9 @@
 package com.pubnub.api.endpoints.objects.membership
 
-import cocoapods.PubNubSwift.AnyJSONObjC
-import cocoapods.PubNubSwift.PubNubChannelMetadataObjC
-import cocoapods.PubNubSwift.PubNubMembershipMetadataObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPAnyJSON
+import cocoapods.PubNubSwift.KMPChannelMetadata
+import cocoapods.PubNubSwift.KMPMembershipMetadata
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeMembershipsWithChannels
 import cocoapods.PubNubSwift.setMembershipsWithChannels
 import com.pubnub.api.models.consumer.objects.PNMembershipKey
@@ -30,7 +30,7 @@ actual interface ManageMemberships : PNFuture<PNChannelMembershipArrayResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class AddMembershipsImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<ChannelMembershipInput>,
     private val uuid: String?,
     private val limit: Int?,
@@ -44,7 +44,7 @@ class AddMembershipsImpl(
 ) : ManageMemberships {
     override fun async(callback: Consumer<Result<PNChannelMembershipArrayResult>>) {
         pubnub.setMembershipsWithChannels(
-            channels = channels.map { PubNubChannelMetadataObjC(it.channel, AnyJSONObjC(it.custom?.value), it.status) },
+            channels = channels.map { KMPChannelMetadata(it.channel, KMPAnyJSON(it.custom?.value), it.status) },
             uuid = uuid,
             limit = limit?.let { NSNumber(it) },
             page = createPubNubHashedPage(from = page),
@@ -58,7 +58,7 @@ class AddMembershipsImpl(
             onSuccess = callback.onSuccessHandler3 { memberships, totalCount, page ->
                 PNChannelMembershipArrayResult(
                     status = 200,
-                    data = memberships.filterAndMap { rawValue: PubNubMembershipMetadataObjC -> createPNChannelMembership(rawValue) },
+                    data = memberships.filterAndMap { rawValue: KMPMembershipMetadata -> createPNChannelMembership(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = page?.start()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = page?.end()?.let { hash -> PNPage.PNPrev(pageHash = hash) }
@@ -71,7 +71,7 @@ class AddMembershipsImpl(
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveMembershipsImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val uuid: String?,
     private val limit: Int?,
@@ -99,7 +99,7 @@ class RemoveMembershipsImpl(
             onSuccess = callback.onSuccessHandler3 { memberships, totalCount, next ->
                 PNChannelMembershipArrayResult(
                     status = 200,
-                    data = memberships.filterAndMap { rawValue: PubNubMembershipMetadataObjC -> createPNChannelMembership(rawValue) },
+                    data = memberships.filterAndMap { rawValue: KMPMembershipMetadata -> createPNChannelMembership(rawValue) },
                     totalCount = totalCount?.intValue,
                     next = next?.end()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = next?.start()?.let { hash -> PNPage.PNPrev(pageHash = hash) }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/GetAllUUIDMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/GetAllUUIDMetadata.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.objects.uuid
 
-import cocoapods.PubNubSwift.PubNubObjC
-import cocoapods.PubNubSwift.PubNubUUIDMetadataObjC
+import cocoapods.PubNubSwift.KMPPubNub
+import cocoapods.PubNubSwift.KMPUUIDMetadata
 import cocoapods.PubNubSwift.getAllUUIDMetadataWithLimit
 import com.pubnub.api.models.consumer.objects.PNKey
 import com.pubnub.api.models.consumer.objects.PNPage
@@ -26,7 +26,7 @@ actual interface GetAllUUIDMetadata : PNFuture<PNUUIDMetadataArrayResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetAllUUIDMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val limit: Int?,
     private val page: PNPage?,
     private val filter: String?,
@@ -45,7 +45,7 @@ class GetAllUUIDMetadataImpl(
             onSuccess = callback.onSuccessHandler3 { uuids, totalCount, next ->
                 PNUUIDMetadataArrayResult(
                     status = 200,
-                    data = uuids.filterAndMap { rawValue: PubNubUUIDMetadataObjC -> createPNUUIDMetadata(from = rawValue) },
+                    data = uuids.filterAndMap { rawValue: KMPUUIDMetadata -> createPNUUIDMetadata(from = rawValue) },
                     totalCount = totalCount?.intValue ?: 0,
                     next = next?.start()?.let { hash -> PNPage.PNNext(pageHash = hash) },
                     prev = next?.end()?.let { hash -> PNPage.PNPrev(pageHash = hash) }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/GetUUIDMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/GetUUIDMetadata.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.objects.uuid
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getUUIDMetadataWithUuid
 import com.pubnub.api.models.consumer.objects.uuid.PNUUIDMetadataResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface GetUUIDMetadata : PNFuture<PNUUIDMetadataResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetUUIDMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val uuid: String?,
     private val includeCustom: Boolean
 ) : GetUUIDMetadata {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/RemoveUUIDMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/RemoveUUIDMetadata.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.objects.uuid
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeUUIDMetadataWithUuid
 import com.pubnub.api.models.consumer.objects.PNRemoveMetadataResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -14,7 +14,7 @@ actual interface RemoveUUIDMetadata : PNFuture<PNRemoveMetadataResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveUUIDMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val uuid: String?
 ) : RemoveUUIDMetadata {
     override fun async(callback: Consumer<Result<PNRemoveMetadataResult>>) {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/SetUUIDMetadata.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/objects/uuid/SetUUIDMetadata.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.objects.uuid
 
-import cocoapods.PubNubSwift.AnyJSONObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPAnyJSON
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.setUUIDMetadataWithUuid
 import com.pubnub.api.models.consumer.objects.uuid.PNUUIDMetadataResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -20,7 +20,7 @@ actual interface SetUUIDMetadata : PNFuture<PNUUIDMetadataResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class SetUUIDMetadataImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val uuid: String?,
     private val name: String?,
     private val externalId: String?,
@@ -38,7 +38,7 @@ class SetUUIDMetadataImpl(
             externalId = externalId,
             profileUrl = profileUrl,
             email = email,
-            custom = AnyJSONObjC(value = custom?.value),
+            custom = KMPAnyJSON(value = custom?.value),
             includeCustom = includeCustom,
             type = type,
             status = status,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/GetState.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/GetState.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.presence
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.getPresenceStateWithChannels
 import com.pubnub.api.models.consumer.presence.PNGetStateResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface GetState : PNFuture<PNGetStateResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class GetStateImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val channelGroups: List<String>,
     private val uuid: String

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/HereNow.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/HereNow.ios.kt
@@ -1,8 +1,8 @@
 package com.pubnub.api.endpoints.presence
 
-import cocoapods.PubNubSwift.PubNubHereNowChannelDataObjC
-import cocoapods.PubNubSwift.PubNubHereNowOccupantDataObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPHereNowChannelData
+import cocoapods.PubNubSwift.KMPHereNowOccupantData
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.hereNowWithChannels
 import com.pubnub.api.JsonElementImpl
 import com.pubnub.api.models.consumer.presence.PNHereNowChannelData
@@ -23,7 +23,7 @@ actual interface HereNow : PNFuture<PNHereNowResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class HereNowImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val channelGroups: List<String>,
     private val includeState: Boolean,
@@ -39,11 +39,11 @@ class HereNowImpl(
                 PNHereNowResult(
                     totalChannels = it?.totalChannels()?.toInt() ?: 0,
                     totalOccupancy = it?.totalOccupancy()?.toInt() ?: 0,
-                    channels = (it?.channels()?.safeCast<String, PubNubHereNowChannelDataObjC>())?.mapValues { entry ->
+                    channels = (it?.channels()?.safeCast<String, KMPHereNowChannelData>())?.mapValues { entry ->
                         PNHereNowChannelData(
                             channelName = entry.value.channelName(),
                             occupancy = entry.value.occupancy().toInt(),
-                            occupants = (entry.value.occupants().filterIsInstance<PubNubHereNowOccupantDataObjC>()).map { occupant ->
+                            occupants = (entry.value.occupants().filterIsInstance<KMPHereNowOccupantData>()).map { occupant ->
                                 PNHereNowOccupantData(
                                     uuid = occupant.uuid(),
                                     state = JsonElementImpl(occupant.state())

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/SetState.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/SetState.ios.kt
@@ -1,7 +1,7 @@
 package com.pubnub.api.endpoints.presence
 
-import cocoapods.PubNubSwift.AnyJSONObjC
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPAnyJSON
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.setPresenceStateWithChannels
 import com.pubnub.api.JsonElementImpl
 import com.pubnub.api.models.consumer.presence.PNSetStateResult
@@ -19,7 +19,7 @@ actual interface SetState : PNFuture<PNSetStateResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class SetStateImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val channelGroups: List<String>,
     private val state: Any,
@@ -28,7 +28,7 @@ class SetStateImpl(
         pubnub.setPresenceStateWithChannels(
             channels = channels,
             channelGroups = channelGroups,
-            state = AnyJSONObjC(value = state),
+            state = KMPAnyJSON(value = state),
             onSuccess = callback.onSuccessHandler { PNSetStateResult(state = JsonElementImpl(it)) },
             onFailure = callback.onFailureHandler()
         )

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/WhereNow.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/presence/WhereNow.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.presence
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.whereNowWithUuid
 import com.pubnub.api.models.consumer.presence.PNWhereNowResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface WhereNow : PNFuture<PNWhereNowResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class WhereNowImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val uuid: String
 ) : WhereNow {
     override fun async(callback: Consumer<Result<PNWhereNowResult>>) {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/pubsub/Publish.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/pubsub/Publish.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.pubsub
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.publishWithChannel
 import com.pubnub.api.models.consumer.PNPublishResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -18,7 +18,7 @@ actual interface Publish : PNFuture<PNPublishResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class PublishImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val message: Any,
     private val meta: Any?,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/pubsub/Signal.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/pubsub/Signal.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.pubsub
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.signalWithChannel
 import com.pubnub.api.models.consumer.PNPublishResult
 import com.pubnub.api.v2.callbacks.Consumer
@@ -17,7 +17,7 @@ actual interface Signal : PNFuture<PNPublishResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class SignalImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channel: String,
     private val message: Any
 ) : Signal {

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/AddChannelsToPush.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/AddChannelsToPush.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.push
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.addChannelsToPushNotificationsWithChannels
 import com.pubnub.api.PubNubException
 import com.pubnub.api.enums.PNPushEnvironment
@@ -23,7 +23,7 @@ actual interface AddChannelsToPush : PNFuture<PNPushAddChannelResult>
 @OptIn(ExperimentalForeignApi::class)
 class AddChannelsToPushImpl(
     private val pushType: PNPushType,
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val deviceId: String,
     private val topic: String?,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/ListPushProvisions.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/ListPushProvisions.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.push
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.listPushChannelsWithDeviceId
 import com.pubnub.api.PubNubException
 import com.pubnub.api.enums.PNPushEnvironment
@@ -22,7 +22,7 @@ actual interface ListPushProvisions : PNFuture<PNPushListProvisionsResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class ListPushProvisionsImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val deviceId: String,
     private val pushType: PNPushType,
     private val topic: String?,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/RemoveAllPushChannelsForDevice.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/RemoveAllPushChannelsForDevice.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.push
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeAllChannelsFromPushWithPushType
 import com.pubnub.api.PubNubException
 import com.pubnub.api.enums.PNPushEnvironment
@@ -22,7 +22,7 @@ actual interface RemoveAllPushChannelsForDevice : PNFuture<PNPushRemoveAllChanne
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveAllPushChannelsForDeviceImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val deviceId: String,
     private val pushType: PNPushType,
     private val topic: String?,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/RemoveChannelsFromPush.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/endpoints/push/RemoveChannelsFromPush.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.endpoints.push
 
-import cocoapods.PubNubSwift.PubNubObjC
+import cocoapods.PubNubSwift.KMPPubNub
 import cocoapods.PubNubSwift.removeChannelsFromPushWithChannels
 import com.pubnub.api.PubNubException
 import com.pubnub.api.enums.PNPushEnvironment
@@ -22,7 +22,7 @@ actual interface RemoveChannelsFromPush : PNFuture<PNPushRemoveChannelResult>
 
 @OptIn(ExperimentalForeignApi::class)
 class RemoveChannelsFromPushImpl(
-    private val pubnub: PubNubObjC,
+    private val pubnub: KMPPubNub,
     private val channels: List<String>,
     private val deviceId: String,
     private val pushType: PNPushType,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/v2/callbacks/EventListener.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/v2/callbacks/EventListener.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.v2.callbacks
 
-import cocoapods.PubNubSwift.PubNubEventListenerObjC
+import cocoapods.PubNubSwift.KMPEventListener
 import com.pubnub.api.PubNub
 import com.pubnub.api.models.consumer.pubsub.PNMessageResult
 import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
@@ -17,7 +17,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 actual interface EventListener : BaseEventListener {
-    val underlying: PubNubEventListenerObjC
+    val underlying: KMPEventListener
     val onMessage: (PubNub, PNMessageResult) -> Unit
     val onPresence: (PubNub, PNPresenceEventResult) -> Unit
     val onSignal: (PubNub, PNSignalResult) -> Unit
@@ -28,7 +28,7 @@ actual interface EventListener : BaseEventListener {
 
 @OptIn(ExperimentalForeignApi::class)
 class EventListenerImpl(
-    override val underlying: PubNubEventListenerObjC,
+    override val underlying: KMPEventListener,
     override val onMessage: (PubNub, PNMessageResult) -> Unit,
     override val onPresence: (PubNub, PNPresenceEventResult) -> Unit,
     override val onSignal: (PubNub, PNSignalResult) -> Unit,

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/v2/callbacks/StatusListener.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/v2/callbacks/StatusListener.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.api.v2.callbacks
 
-import cocoapods.PubNubSwift.PubNubStatusListenerObjC
+import cocoapods.PubNubSwift.KMPStatusListener
 import com.pubnub.api.PubNub
 import com.pubnub.api.callbacks.Listener
 import com.pubnub.api.models.consumer.PNStatus
@@ -12,12 +12,12 @@ import kotlinx.cinterop.ExperimentalForeignApi
  */
 @OptIn(ExperimentalForeignApi::class)
 actual interface StatusListener : Listener {
-    val underlying: PubNubStatusListenerObjC
+    val underlying: KMPStatusListener
     val onStatusChange: (PubNub, PNStatus) -> Unit
 }
 
 @OptIn(ExperimentalForeignApi::class)
 class StatusListenerImpl(
-    override val underlying: PubNubStatusListenerObjC,
+    override val underlying: KMPStatusListener,
     override val onStatusChange: (PubNub, PNStatus) -> Unit
 ) : StatusListener

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/ChannelGroupImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/ChannelGroupImpl.kt
@@ -1,7 +1,7 @@
 package com.pubnub.internal.entities
 
-import cocoapods.PubNubSwift.PubNubChannelGroupEntityObjC
-import cocoapods.PubNubSwift.PubNubSubscriptionObjC
+import cocoapods.PubNubSwift.KMPChannelGroupEntity
+import cocoapods.PubNubSwift.KMPSubscription
 import com.pubnub.api.v2.entities.ChannelGroup
 import com.pubnub.api.v2.subscriptions.Subscription
 import com.pubnub.api.v2.subscriptions.SubscriptionOptions
@@ -10,13 +10,13 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 class ChannelGroupImpl(
-    private val channelGroup: PubNubChannelGroupEntityObjC
+    private val channelGroup: KMPChannelGroupEntity
 ) : ChannelGroup {
     override val name: String
         get() = channelGroup.name()
 
     override fun subscription(options: SubscriptionOptions): Subscription {
         // TODO: Add support for handling SubscriptionOptions
-        return SubscriptionImpl(objCSubscription = PubNubSubscriptionObjC(entity = channelGroup))
+        return SubscriptionImpl(objCSubscription = KMPSubscription(entity = channelGroup))
     }
 }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/ChannelImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/ChannelImpl.kt
@@ -1,7 +1,7 @@
 package com.pubnub.internal.entities
 
-import cocoapods.PubNubSwift.PubNubChannelEntityObjC
-import cocoapods.PubNubSwift.PubNubSubscriptionObjC
+import cocoapods.PubNubSwift.KMPChannelEntity
+import cocoapods.PubNubSwift.KMPSubscription
 import com.pubnub.api.endpoints.files.DeleteFile
 import com.pubnub.api.endpoints.files.SendFile
 import com.pubnub.api.endpoints.pubsub.Publish
@@ -16,7 +16,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 class ChannelImpl(
-    private val channel: PubNubChannelEntityObjC
+    private val channel: KMPChannelEntity
 ) : Channel {
     override fun publish(
         message: Any,
@@ -59,7 +59,7 @@ class ChannelImpl(
     // TODO: Add support for handling SubscriptionOptions
     override fun subscription(options: SubscriptionOptions): Subscription {
         val presenceOptions = options.allOptions.filterIsInstance<ReceivePresenceEventsImpl>()
-        val objcSubscription = PubNubSubscriptionObjC(channel, presenceOptions.isNotEmpty())
+        val objcSubscription = KMPSubscription(channel, presenceOptions.isNotEmpty())
 
         return SubscriptionImpl(objcSubscription)
     }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/ChannelMetadataImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/ChannelMetadataImpl.kt
@@ -1,7 +1,7 @@
 package com.pubnub.internal.entities
 
-import cocoapods.PubNubSwift.PubNubChannelMetadataEntityObjC
-import cocoapods.PubNubSwift.PubNubSubscriptionObjC
+import cocoapods.PubNubSwift.KMPChannelMetadataEntity
+import cocoapods.PubNubSwift.KMPSubscription
 import com.pubnub.api.v2.entities.ChannelMetadata
 import com.pubnub.api.v2.subscriptions.Subscription
 import com.pubnub.api.v2.subscriptions.SubscriptionOptions
@@ -10,13 +10,13 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 class ChannelMetadataImpl(
-    private val channelMetadata: PubNubChannelMetadataEntityObjC
+    private val channelMetadata: KMPChannelMetadataEntity
 ) : ChannelMetadata {
     override val id: String
         get() = channelMetadata.name()
 
     override fun subscription(options: SubscriptionOptions): Subscription {
         // TODO: Add support for handling SubscriptionOptions
-        return SubscriptionImpl(objCSubscription = PubNubSubscriptionObjC(entity = channelMetadata))
+        return SubscriptionImpl(objCSubscription = KMPSubscription(entity = channelMetadata))
     }
 }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/UserMetadataImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/entities/UserMetadataImpl.kt
@@ -1,7 +1,7 @@
 package com.pubnub.internal.entities
 
-import cocoapods.PubNubSwift.PubNubSubscriptionObjC
-import cocoapods.PubNubSwift.PubNubUserMetadataEntityObjC
+import cocoapods.PubNubSwift.KMPSubscription
+import cocoapods.PubNubSwift.KMPUserMetadataEntity
 import com.pubnub.api.v2.entities.UserMetadata
 import com.pubnub.api.v2.subscriptions.Subscription
 import com.pubnub.api.v2.subscriptions.SubscriptionOptions
@@ -10,13 +10,13 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 class UserMetadataImpl(
-    private val userMetadata: PubNubUserMetadataEntityObjC
+    private val userMetadata: KMPUserMetadataEntity
 ) : UserMetadata {
     override val id: String
         get() = userMetadata.name()
 
     override fun subscription(options: SubscriptionOptions): Subscription {
         // TODO: Add support for handling SubscriptionOptions
-        return SubscriptionImpl(objCSubscription = PubNubSubscriptionObjC(entity = userMetadata))
+        return SubscriptionImpl(objCSubscription = KMPSubscription(entity = userMetadata))
     }
 }

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/subscription/SubscriptionImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/subscription/SubscriptionImpl.kt
@@ -1,6 +1,6 @@
 package com.pubnub.internal.subscription
 
-import cocoapods.PubNubSwift.PubNubSubscriptionObjC
+import cocoapods.PubNubSwift.KMPSubscription
 import com.pubnub.api.callbacks.Listener
 import com.pubnub.api.models.consumer.pubsub.PNMessageResult
 import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
@@ -16,7 +16,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 class SubscriptionImpl(
-    val objCSubscription: PubNubSubscriptionObjC
+    val objCSubscription: KMPSubscription
 ) : Subscription {
     override fun close() {
         objCSubscription.dispose()

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/subscription/SubscriptionSetImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/internal/subscription/SubscriptionSetImpl.kt
@@ -1,6 +1,6 @@
 package com.pubnub.internal.subscription
 
-import cocoapods.PubNubSwift.PubNubSubscriptionSetObjC
+import cocoapods.PubNubSwift.KMPSubscriptionSet
 import com.pubnub.api.callbacks.Listener
 import com.pubnub.api.models.consumer.pubsub.PNMessageResult
 import com.pubnub.api.models.consumer.pubsub.PNPresenceEventResult
@@ -16,7 +16,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 
 @OptIn(ExperimentalForeignApi::class)
 class SubscriptionSetImpl(
-    private val objCSubscriptionSet: PubNubSubscriptionSetObjC
+    private val objCSubscriptionSet: KMPSubscriptionSet
 ) : SubscriptionSet {
     override fun close() {
         objCSubscriptionSet.dispose()

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/kmp/converters.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/kmp/converters.kt
@@ -1,10 +1,10 @@
 package com.pubnub.kmp
 
-import cocoapods.PubNubSwift.PubNubChannelMetadataObjC
-import cocoapods.PubNubSwift.PubNubHashedPageObjC
-import cocoapods.PubNubSwift.PubNubMembershipMetadataObjC
-import cocoapods.PubNubSwift.PubNubObjectSortPropertyObjC
-import cocoapods.PubNubSwift.PubNubUUIDMetadataObjC
+import cocoapods.PubNubSwift.KMPChannelMetadata
+import cocoapods.PubNubSwift.KMPHashedPage
+import cocoapods.PubNubSwift.KMPMembershipMetadata
+import cocoapods.PubNubSwift.KMPObjectSortProperty
+import cocoapods.PubNubSwift.KMPUUIDMetadata
 import com.pubnub.api.models.consumer.objects.PNKey
 import com.pubnub.api.models.consumer.objects.PNPage
 import com.pubnub.api.models.consumer.objects.PNSortKey
@@ -24,8 +24,8 @@ internal fun String.toNSData(): NSData? {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-internal fun createPubNubHashedPage(from: PNPage?): PubNubHashedPageObjC {
-    return PubNubHashedPageObjC(
+internal fun createPubNubHashedPage(from: PNPage?): KMPHashedPage {
+    return KMPHashedPage(
         start = if (from is PNPage.PNNext) {
             from.pageHash
         } else {
@@ -42,7 +42,7 @@ internal fun createPubNubHashedPage(from: PNPage?): PubNubHashedPageObjC {
 
 // TODO: PatchValue should consider cases where there is no response for a given field
 @OptIn(ExperimentalForeignApi::class)
-internal fun createPNUUIDMetadata(from: PubNubUUIDMetadataObjC?): PNUUIDMetadata {
+internal fun createPNUUIDMetadata(from: KMPUUIDMetadata?): PNUUIDMetadata {
     return PNUUIDMetadata(
         id = from!!.id(),
         name = PatchValue.of(from.name()),
@@ -59,7 +59,7 @@ internal fun createPNUUIDMetadata(from: PubNubUUIDMetadataObjC?): PNUUIDMetadata
 
 // TODO: PatchValue should consider cases where there is no response for a given field
 @OptIn(ExperimentalForeignApi::class)
-internal fun createPNChannelMetadata(from: PubNubChannelMetadataObjC?): PNChannelMetadata {
+internal fun createPNChannelMetadata(from: KMPChannelMetadata?): PNChannelMetadata {
     return PNChannelMetadata(
         id = from!!.id(),
         name = PatchValue.of(from.name()),
@@ -73,9 +73,9 @@ internal fun createPNChannelMetadata(from: PubNubChannelMetadataObjC?): PNChanne
 }
 
 @OptIn(ExperimentalForeignApi::class)
-internal fun createObjectSortProperties(from: Collection<PNSortKey<PNKey>>): List<PubNubObjectSortPropertyObjC> {
+internal fun createObjectSortProperties(from: Collection<PNSortKey<PNKey>>): List<KMPObjectSortProperty> {
     return from.map {
-        PubNubObjectSortPropertyObjC(
+        KMPObjectSortProperty(
             key = it.key.fieldName,
             direction = it.dir
         )
@@ -84,7 +84,7 @@ internal fun createObjectSortProperties(from: Collection<PNSortKey<PNKey>>): Lis
 
 // TODO: PatchValue should consider cases where there is no response for a given field
 @OptIn(ExperimentalForeignApi::class)
-internal fun createPNChannelMembership(from: PubNubMembershipMetadataObjC): PNChannelMembership {
+internal fun createPNChannelMembership(from: KMPMembershipMetadata): PNChannelMembership {
     return PNChannelMembership(
         channel = PNChannelMetadata(
             id = from.channelMetadataId(),
@@ -105,7 +105,7 @@ internal fun createPNChannelMembership(from: PubNubMembershipMetadataObjC): PNCh
 
 // TODO: PatchValue should consider cases where there is no response for a given field
 @OptIn(ExperimentalForeignApi::class)
-internal fun createPNMember(from: PubNubMembershipMetadataObjC?): PNMember {
+internal fun createPNMember(from: KMPMembershipMetadata?): PNMember {
     return PNMember(
         uuid = createPNUUIDMetadata(from = from!!.uuid()),
         custom = PatchValue.of(from.custom()?.safeCast()),

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/kmp/factories.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/kmp/factories.ios.kt
@@ -1,26 +1,26 @@
 package com.pubnub.kmp
 
-import cocoapods.PubNubSwift.PubNubAppContextEventObjC
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCConnected
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCConnectionError
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCDisconnected
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCDisconnectedUnexpectedly
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCHeartbeatFailed
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCHeartbeatSuccess
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCMalformedResponseCategory
-import cocoapods.PubNubSwift.PubNubConnectionStatusCategoryObjCSubscriptionChanged
-import cocoapods.PubNubSwift.PubNubEventListenerObjC
-import cocoapods.PubNubSwift.PubNubFileChangeEventObjC
-import cocoapods.PubNubSwift.PubNubMessageActionObjC
-import cocoapods.PubNubSwift.PubNubMessageObjC
-import cocoapods.PubNubSwift.PubNubPresenceChangeObjC
-import cocoapods.PubNubSwift.PubNubRemoveChannelMetadataResultObjC
-import cocoapods.PubNubSwift.PubNubRemoveMembershipResultObjC
-import cocoapods.PubNubSwift.PubNubRemoveUUIDMetadataResultObjC
-import cocoapods.PubNubSwift.PubNubSetChannelMetadataResultObjC
-import cocoapods.PubNubSwift.PubNubSetMembershipResultObjC
-import cocoapods.PubNubSwift.PubNubSetUUIDMetadataResultObjC
-import cocoapods.PubNubSwift.PubNubStatusListenerObjC
+import cocoapods.PubNubSwift.KMPAppContextEventResult
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryConnected
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryConnectionError
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryDisconnected
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryDisconnectedUnexpectedly
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryHeartbeatFailed
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryHeartbeatSuccess
+import cocoapods.PubNubSwift.KMPConnectionStatusCategoryMalformedResponseCategory
+import cocoapods.PubNubSwift.KMPConnectionStatusCategorySubscriptionChanged
+import cocoapods.PubNubSwift.KMPEventListener
+import cocoapods.PubNubSwift.KMPFileChangeEvent
+import cocoapods.PubNubSwift.KMPMessage
+import cocoapods.PubNubSwift.KMPMessageAction
+import cocoapods.PubNubSwift.KMPPresenceChange
+import cocoapods.PubNubSwift.KMPRemoveChannelMetadataResult
+import cocoapods.PubNubSwift.KMPRemoveMembershipResult
+import cocoapods.PubNubSwift.KMPRemoveUUIDMetadataResult
+import cocoapods.PubNubSwift.KMPSetChannelMetadataResult
+import cocoapods.PubNubSwift.KMPSetMembershipResult
+import cocoapods.PubNubSwift.KMPSetUUIDMetadataResult
+import cocoapods.PubNubSwift.KMPStatusListener
 import com.pubnub.api.JsonElementImpl
 import com.pubnub.api.PubNub
 import com.pubnub.api.PubNubException
@@ -70,7 +70,7 @@ actual fun createEventListener(
     onFile: (PubNub, PNFileEventResult) -> Unit
 ): EventListener {
     return EventListenerImpl(
-        underlying = PubNubEventListenerObjC(
+        underlying = KMPEventListener(
             onMessage = { onMessage(pubnub, createMessageResult(it)) },
             onPresence = { presenceEvents -> createPresenceEventResults(presenceEvents).forEach { onPresence(pubnub, it) } },
             onSignal = { onSignal(pubnub, createSignalResult(it)) },
@@ -88,7 +88,7 @@ actual fun createEventListener(
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun createMessageResult(from: PubNubMessageObjC?): PNMessageResult {
+private fun createMessageResult(from: KMPMessage?): PNMessageResult {
     return PNMessageResult(
         basePubSubResult = BasePubSubResult(
             channel = from!!.channel(),
@@ -103,7 +103,7 @@ private fun createMessageResult(from: PubNubMessageObjC?): PNMessageResult {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun createSignalResult(from: PubNubMessageObjC?): PNSignalResult {
+private fun createSignalResult(from: KMPMessage?): PNSignalResult {
     return PNSignalResult(
         basePubSubResult = BasePubSubResult(
             channel = from!!.channel(),
@@ -117,7 +117,7 @@ private fun createSignalResult(from: PubNubMessageObjC?): PNSignalResult {
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun createMessageActionResult(from: PubNubMessageActionObjC?): PNMessageActionResult {
+private fun createMessageActionResult(from: KMPMessageAction?): PNMessageActionResult {
     val messageAction = PNMessageAction(
         type = from!!.actionType(),
         value = from.actionValue(),
@@ -142,7 +142,7 @@ private fun createMessageActionResult(from: PubNubMessageActionObjC?): PNMessage
 
 @OptIn(ExperimentalForeignApi::class)
 private fun createPresenceEventResults(from: List<*>?): List<PNPresenceEventResult> {
-    return from.filterAndMap { rawValue: PubNubPresenceChangeObjC ->
+    return from.filterAndMap { rawValue: KMPPresenceChange ->
         PNPresenceEventResult(
             event = rawValue.event(),
             uuid = rawValue.uuid(),
@@ -162,7 +162,7 @@ private fun createPresenceEventResults(from: List<*>?): List<PNPresenceEventResu
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun createFileEventResult(from: PubNubFileChangeEventObjC?): PNFileEventResult {
+private fun createFileEventResult(from: KMPFileChangeEvent?): PNFileEventResult {
     return PNFileEventResult(
         channel = from!!.channel(),
         timetoken = from.timetoken()?.longValue,
@@ -178,7 +178,7 @@ private fun createFileEventResult(from: PubNubFileChangeEventObjC?): PNFileEvent
 }
 
 @OptIn(ExperimentalForeignApi::class)
-private fun createObjectEvent(from: PubNubAppContextEventObjC?): PNObjectEventResult? {
+private fun createObjectEvent(from: KMPAppContextEventResult?): PNObjectEventResult? {
     return mapAppContextEvent(from)?.let {
         PNObjectEventResult(
             result = BasePubSubResult(
@@ -195,9 +195,9 @@ private fun createObjectEvent(from: PubNubAppContextEventObjC?): PNObjectEventRe
 
 // TODO: PatchValue should consider cases where there is no response for a given field
 @OptIn(ExperimentalForeignApi::class)
-private fun mapAppContextEvent(from: PubNubAppContextEventObjC?): PNObjectEventMessage? {
+private fun mapAppContextEvent(from: KMPAppContextEventResult?): PNObjectEventMessage? {
     when (from) {
-        is PubNubSetUUIDMetadataResultObjC ->
+        is KMPSetUUIDMetadataResult ->
             return PNSetUUIDMetadataEventMessage(
                 source = from.source(),
                 version = from.version(),
@@ -205,18 +205,46 @@ private fun mapAppContextEvent(from: PubNubAppContextEventObjC?): PNObjectEventM
                 type = from.type(),
                 data = PNUUIDMetadata(
                     id = from.metadata().id(),
-                    name = if (from.metadata().hasName()) { PatchValue.of(from.metadata().name()) } else { null },
-                    externalId = if (from.metadata().hasExternalId()) { PatchValue.of(from.metadata().externalId()) } else { null },
-                    profileUrl = if (from.metadata().hasProfileUrl()) { PatchValue.of(from.metadata().profileUrl()) } else { null },
-                    email = if (from.metadata().hasEmail()) { PatchValue.of(from.metadata().email()) } else { null },
-                    custom = if (from.metadata().hasCustom()) { PatchValue.of(from.metadata().custom()?.safeCast<String, Any?>()) } else { null },
+                    name = if (from.metadata().hasName()) {
+                        PatchValue.of(from.metadata().name())
+                    } else {
+                        null
+                    },
+                    externalId = if (from.metadata().hasExternalId()) {
+                        PatchValue.of(from.metadata().externalId())
+                    } else {
+                        null
+                    },
+                    profileUrl = if (from.metadata().hasProfileUrl()) {
+                        PatchValue.of(from.metadata().profileUrl())
+                    } else {
+                        null
+                    },
+                    email = if (from.metadata().hasEmail()) {
+                        PatchValue.of(from.metadata().email())
+                    } else {
+                        null
+                    },
+                    custom = if (from.metadata().hasCustom()) {
+                        PatchValue.of(from.metadata().custom()?.safeCast<String, Any?>())
+                    } else {
+                        null
+                    },
                     updated = from.metadata().updated()?.let { PatchValue.of(it) },
                     eTag = from.metadata().eTag()?.let { PatchValue.of(it) },
-                    type = if (from.metadata().hasType()) { PatchValue.of(from.metadata().type()) } else { null },
-                    status = if (from.metadata().hasStatus()) { PatchValue.of(from.metadata().status()) } else { null }
+                    type = if (from.metadata().hasType()) {
+                        PatchValue.of(from.metadata().type())
+                    } else {
+                        null
+                    },
+                    status = if (from.metadata().hasStatus()) {
+                        PatchValue.of(from.metadata().status())
+                    } else {
+                        null
+                    }
                 )
             )
-        is PubNubRemoveUUIDMetadataResultObjC ->
+        is KMPRemoveUUIDMetadataResult ->
             return PNDeleteUUIDMetadataEventMessage(
                 source = from.source(),
                 version = from.version(),
@@ -224,7 +252,7 @@ private fun mapAppContextEvent(from: PubNubAppContextEventObjC?): PNObjectEventM
                 type = from.type(),
                 uuid = from.uuid()
             )
-        is PubNubSetChannelMetadataResultObjC ->
+        is KMPSetChannelMetadataResult ->
             return PNSetChannelMetadataEventMessage(
                 source = from.source(),
                 version = from.version(),
@@ -232,16 +260,36 @@ private fun mapAppContextEvent(from: PubNubAppContextEventObjC?): PNObjectEventM
                 type = from.type(),
                 data = PNChannelMetadata(
                     id = from.metadata().id(),
-                    name = if (from.metadata().hasName()) { PatchValue.of(from.metadata().name()) } else { null },
-                    description = if (from.metadata().hasDescr()) { PatchValue.of(from.metadata().descr()) } else { null },
-                    custom = if (from.metadata().hasCustom()) { PatchValue.of(from.metadata().custom()?.safeCast<String, Any?>()) } else { null },
+                    name = if (from.metadata().hasName()) {
+                        PatchValue.of(from.metadata().name())
+                    } else {
+                        null
+                    },
+                    description = if (from.metadata().hasDescr()) {
+                        PatchValue.of(from.metadata().descr())
+                    } else {
+                        null
+                    },
+                    custom = if (from.metadata().hasCustom()) {
+                        PatchValue.of(from.metadata().custom()?.safeCast<String, Any?>())
+                    } else {
+                        null
+                    },
                     updated = from.metadata().updated()?.let { PatchValue.of(it) },
                     eTag = from.metadata().eTag()?.let { PatchValue.of(it) },
-                    type = if (from.metadata().hasType()) { PatchValue.of(from.metadata().type()) } else { null },
-                    status = if (from.metadata().hasStatus()) { PatchValue.of(from.metadata().status()) } else { null }
+                    type = if (from.metadata().hasType()) {
+                        PatchValue.of(from.metadata().type())
+                    } else {
+                        null
+                    },
+                    status = if (from.metadata().hasStatus()) {
+                        PatchValue.of(from.metadata().status())
+                    } else {
+                        null
+                    }
                 )
             )
-        is PubNubRemoveChannelMetadataResultObjC ->
+        is KMPRemoveChannelMetadataResult ->
             return PNDeleteChannelMetadataEventMessage(
                 source = from.source(),
                 version = from.version(),
@@ -249,7 +297,7 @@ private fun mapAppContextEvent(from: PubNubAppContextEventObjC?): PNObjectEventM
                 type = from.type(),
                 channel = from.channel()
             )
-        is PubNubSetMembershipResultObjC ->
+        is KMPSetMembershipResult ->
             return PNSetMembershipEventMessage(
                 source = from.source(),
                 version = from.version(),
@@ -264,7 +312,7 @@ private fun mapAppContextEvent(from: PubNubAppContextEventObjC?): PNObjectEventM
                     status = PatchValue.of(from.metadata().status().orEmpty())
                 )
             )
-        is PubNubRemoveMembershipResultObjC ->
+        is KMPRemoveMembershipResult ->
             return PNDeleteMembershipEventMessage(
                 source = from.source(),
                 version = from.version(),
@@ -285,23 +333,23 @@ actual fun createStatusListener(
     onStatus: (PubNub, PNStatus) -> Unit
 ): StatusListener {
     return StatusListenerImpl(
-        underlying = PubNubStatusListenerObjC(onStatusChange = { status ->
+        underlying = KMPStatusListener(onStatusChange = { status ->
             when (status?.category()) {
-                PubNubConnectionStatusCategoryObjCConnected ->
+                KMPConnectionStatusCategoryConnected ->
                     PNStatusCategory.PNConnectedCategory
-                PubNubConnectionStatusCategoryObjCDisconnected ->
+                KMPConnectionStatusCategoryDisconnected ->
                     PNStatusCategory.PNDisconnectedCategory
-                PubNubConnectionStatusCategoryObjCDisconnectedUnexpectedly ->
+                KMPConnectionStatusCategoryDisconnectedUnexpectedly ->
                     PNStatusCategory.PNUnexpectedDisconnectCategory
-                PubNubConnectionStatusCategoryObjCConnectionError ->
+                KMPConnectionStatusCategoryConnectionError ->
                     PNStatusCategory.PNConnectionError
-                PubNubConnectionStatusCategoryObjCMalformedResponseCategory ->
+                KMPConnectionStatusCategoryMalformedResponseCategory ->
                     PNStatusCategory.PNMalformedResponseCategory
-                PubNubConnectionStatusCategoryObjCHeartbeatFailed ->
+                KMPConnectionStatusCategoryHeartbeatFailed ->
                     PNStatusCategory.PNHeartbeatFailed
-                PubNubConnectionStatusCategoryObjCHeartbeatSuccess ->
+                KMPConnectionStatusCategoryHeartbeatSuccess ->
                     PNStatusCategory.PNHeartbeatSuccess
-                PubNubConnectionStatusCategoryObjCSubscriptionChanged ->
+                KMPConnectionStatusCategorySubscriptionChanged ->
                     PNStatusCategory.PNSubscriptionChanged
                 else -> null
             }?.let { category ->

--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/kmp/results.ios.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/kmp/results.ios.kt
@@ -1,6 +1,6 @@
 package com.pubnub.kmp
 
-import cocoapods.PubNubSwift.PubNubErrorObjC
+import cocoapods.PubNubSwift.KMPError
 import com.pubnub.api.PubNubException
 import com.pubnub.api.v2.callbacks.Consumer
 import com.pubnub.api.v2.callbacks.Result
@@ -52,7 +52,7 @@ fun <T> Consumer<Result<T>>.onSuccessReturnValue(value: T): () -> Unit {
 @OptIn(ExperimentalForeignApi::class)
 fun <T> Consumer<Result<T>>.onFailureHandler(
     mapper: (NSError?) -> Throwable = { error: NSError? ->
-        if (error is PubNubErrorObjC) {
+        if (error is KMPError) {
             PubNubException(error.statusCode().toInt(), error.localizedDescription, null)
         } else {
             PubNubException(errorMessage = error?.localizedDescription)


### PR DESCRIPTION
- Fixed import statements in iosMain due to names refactor (adding the `KMP` prefix) in the `swift` submodule.
- Made changes in the `swift` submodule, replacing the product name with `PubNubSDK` due to a compiler error that prevents emitting the module interface if one of the module's classes has the same name as the module itself
- Changed module name in `PubNubKotlinMultiplatformPlugin.kt`