### PR TITLE
Added @ObjCName annotation and helper constructor (iOS)

### DIFF
--- a/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/PubNubImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/iosMain/kotlin/com/pubnub/api/PubNubImpl.kt
@@ -152,6 +152,12 @@ class PubNubImpl(private val pubNubObjC: KMPPubNub) : PubNub {
         )
     )
 
+    companion object {
+        fun create(kmpPubNub: Any): PubNubImpl {
+            return PubNubImpl(kmpPubNub as KMPPubNub)
+        }
+    }
+
     override val configuration: PNConfiguration = createPNConfiguration(
         UserId(pubNubObjC.configObjC().userId()),
         "", // todo

--- a/pubnub-kotlin/pubnub-kotlin-api/src/nonJvm/kotlin/com/pubnub/api/PubNub.nonJvm.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/nonJvm/kotlin/com/pubnub/api/PubNub.nonJvm.kt
@@ -72,7 +72,10 @@ import com.pubnub.api.v2.subscriptions.SubscriptionOptions
 import com.pubnub.api.v2.subscriptions.SubscriptionSet
 import com.pubnub.kmp.CustomObject
 import com.pubnub.kmp.Uploadable
+import kotlin.experimental.ExperimentalObjCName
 
+@OptIn(ExperimentalObjCName::class)
+@ObjCName("PubNubInterface")
 actual interface PubNub {
     actual val configuration: PNConfiguration
 


### PR DESCRIPTION
- Added `@ObjCName` annotation due to `PubNub` name ambiguity. It's present both in KMP binary and Swift SDK. This fix prevents us from adding prefixes in the Swift chat layer 
- Added companion object for `PubNubImpl` in iOS. Xcode does not allow me to call a default constructor and it can't infer that the `KMPPubNub` type belongs to Swift Chat SDK. Fortunately, this change is completely hidden from any customer