### PR TITLE
Fix for NullPointerException in Grant

### DIFF
--- a/pubnub-gson/pubnub-gson-api/src/main/java/com/pubnub/api/java/models/consumer/access_manager/PNAccessManagerGrantResult.java
+++ b/pubnub-gson/pubnub-gson-api/src/main/java/com/pubnub/api/java/models/consumer/access_manager/PNAccessManagerGrantResult.java
@@ -39,8 +39,14 @@ public class PNAccessManagerGrantResult {
     private static Map<String, Map<String, PNAccessManagerKeyData>> from(Map<String, Map<String, com.pubnub.api.models.consumer.access_manager.PNAccessManagerKeyData>> data) {
         Map<String, Map<String, PNAccessManagerKeyData>> newMap = new HashMap<>(data.size());
         for (Map.Entry<String, Map<String, com.pubnub.api.models.consumer.access_manager.PNAccessManagerKeyData>> stringMapEntry : data.entrySet()) {
+            if (stringMapEntry.getValue() == null) {
+                continue;
+            }
             Map<String, PNAccessManagerKeyData> innerMap = new HashMap<>(stringMapEntry.getValue().size());
             for (Map.Entry<String, com.pubnub.api.models.consumer.access_manager.PNAccessManagerKeyData> innerEntry : stringMapEntry.getValue().entrySet()) {
+                if (innerEntry.getValue() == null) {
+                    continue;
+                }
                 innerMap.put(innerEntry.getKey(), PNAccessManagerKeyData.from(innerEntry.getValue()));
             }
             newMap.put(stringMapEntry.getKey(), innerMap);

--- a/pubnub-gson/pubnub-gson-api/src/main/java/com/pubnub/api/java/models/consumer/access_manager/PNAccessManagerKeyData.java
+++ b/pubnub-gson/pubnub-gson-api/src/main/java/com/pubnub/api/java/models/consumer/access_manager/PNAccessManagerKeyData.java
@@ -3,6 +3,7 @@ package com.pubnub.api.java.models.consumer.access_manager;
 import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.Data;
+import org.jetbrains.annotations.NotNull;
 
 @Data
 @Builder(toBuilder = true)
@@ -29,7 +30,8 @@ public class PNAccessManagerKeyData {
     @SerializedName("j")
     private boolean joinEnabled;
 
-    static PNAccessManagerKeyData from(com.pubnub.api.models.consumer.access_manager.PNAccessManagerKeyData data) {
+    @NotNull
+    static PNAccessManagerKeyData from(@NotNull com.pubnub.api.models.consumer.access_manager.PNAccessManagerKeyData data) {
         return PNAccessManagerKeyData.builder()
                 .readEnabled(data.getReadEnabled())
                 .writeEnabled(data.getWriteEnabled())

--- a/pubnub-gson/pubnub-gson-impl/src/integrationTest/java/com/pubnub/api/integration/pam/GrantIT.java
+++ b/pubnub-gson/pubnub-gson-impl/src/integrationTest/java/com/pubnub/api/integration/pam/GrantIT.java
@@ -6,6 +6,7 @@ import com.pubnub.api.java.models.consumer.access_manager.PNAccessManagerGrantRe
 import com.pubnub.api.java.models.consumer.access_manager.PNAccessManagerKeyData;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -13,11 +14,15 @@ import static org.junit.Assert.assertEquals;
 public class GrantIT extends BaseIntegrationTest {
 
     @Test
+    public void grantWithoutAuthKeyDoesntCrash() throws PubNubException {
+        getServer().grant().channels(Arrays.asList("abc")).write(true).read(false).ttl(0).sync();
+    }
+
+    @Test
     public void grantAllForUUID() throws PubNubException {
         String uuid = "uuid123";
         String authKey = "authKey123";
         int ttl = 120;
-
         PNAccessManagerGrantResult expectedResult = PNAccessManagerGrantResult.builder()
                 .channelGroups(Collections.emptyMap())
                 .channels(Collections.emptyMap())
@@ -35,7 +40,7 @@ public class GrantIT extends BaseIntegrationTest {
                         .build())))
                 .build();
 
-        PNAccessManagerGrantResult result = getServer()
+        PNAccessManagerGrantResult result2 = getServer()
                 .grant()
                 .uuids(Collections.singletonList(uuid))
                 .authKeys(Collections.singletonList(authKey))
@@ -44,7 +49,6 @@ public class GrantIT extends BaseIntegrationTest {
                 .update(true)
                 .delete(true)
                 .sync();
-        System.out.println(result);
-        assertEquals(expectedResult, result);
+        assertEquals(expectedResult, result2);
     }
 }


### PR DESCRIPTION
In `pubnub-gson`, when grant() is called without authKeys there was a NullPointerException.