### PR TITLE
[JS] Fix getMemberships ignoring `uuid` parameter

### DIFF
--- a/pubnub-kotlin/pubnub-kotlin-api/src/commonTest/kotlin/com/pubnub/test/integration/MembershipsTest.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/commonTest/kotlin/com/pubnub/test/integration/MembershipsTest.kt
@@ -42,6 +42,25 @@ class MembershipsTest : BaseIntegrationTest() {
     }
 
     @Test
+    fun can_set_and_get_memberships_for_other_uuid() = runTest {
+        // when
+        val userId = "some-user-" + randomString()
+        pubnub.setMemberships(
+            channels = listOf(PNChannelMembership.Partial(channel, custom, status)),
+            uuid = userId,
+            includeCustom = includeCustom,
+            includeChannelDetails = PNChannelDetailsLevel.CHANNEL_WITH_CUSTOM,
+        ).await()
+
+        val result = pubnub.getMemberships(uuid = userId, filter = "channel.id == '$channel'", includeCustom = true).await()
+
+        // then
+        val pnChannelDetails = result.data.single { it.channel.id == channel }
+        assertEquals(channel, pnChannelDetails.channel.id)
+        assertEquals(customData, pnChannelDetails.custom?.value)
+    }
+
+    @Test
     fun can_receive_set_membership_event() = runTest {
         pubnub.test(backgroundScope) {
             // given

--- a/pubnub-kotlin/pubnub-kotlin-api/src/commonTest/kotlin/com/pubnub/test/integration/PublishTest.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/commonTest/kotlin/com/pubnub/test/integration/PublishTest.kt
@@ -11,6 +11,7 @@ import com.pubnub.api.models.consumer.pubsub.PNSignalResult
 import com.pubnub.kmp.PLATFORM
 import com.pubnub.test.BaseIntegrationTest
 import com.pubnub.test.await
+import com.pubnub.test.randomString
 import com.pubnub.test.test
 import kotlinx.coroutines.test.runTest
 import kotlin.js.JsExport
@@ -27,7 +28,7 @@ data class ABC(
 )
 
 class PublishTest : BaseIntegrationTest() {
-    private val channel = "myChannel"
+    private val channel = "myChannel" + randomString()
 
     @Test
     fun can_publish_message_string() =

--- a/pubnub-kotlin/pubnub-kotlin-api/src/jsMain/kotlin/com/pubnub/api/PubNubImpl.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/jsMain/kotlin/com/pubnub/api/PubNubImpl.kt
@@ -676,6 +676,7 @@ class PubNubImpl(val jsPubNub: PubNubJs) : PubNub {
         return GetMembershipsImpl(
             jsPubNub,
             createJsObject {
+                uuid?.let { this.uuid = it }
                 this.sort = sort.toJsMap()
                 this.filter = filter
                 this.page = page.toMetadataPage()


### PR DESCRIPTION
Fixes a bug in the JS wrapper in getMemberships + adds test