### PR TITLE
Added validation for Leave and Heartbeat

### DIFF
--- a/pubnub-kotlin/pubnub-kotlin-core-api/src/commonMain/kotlin/com/pubnub/api/PubNubError.kt
+++ b/pubnub-kotlin/pubnub-kotlin-core-api/src/commonMain/kotlin/com/pubnub/api/PubNubError.kt
@@ -234,6 +234,11 @@ enum class PubNubError(private val code: Int, val message: String) {
         180,
         "UserId can't be different from UserId in configuration when flag withHeartbeat is set to true",
     ),
+
+    CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING(
+        181,
+        "Channel and/or ChannelGroup contains empty string which is not allowed.",
+    ),
     ;
 
     override fun toString(): String {

--- a/pubnub-kotlin/pubnub-kotlin-impl/src/main/kotlin/com/pubnub/internal/endpoints/presence/HeartbeatEndpoint.kt
+++ b/pubnub-kotlin/pubnub-kotlin-impl/src/main/kotlin/com/pubnub/internal/endpoints/presence/HeartbeatEndpoint.kt
@@ -22,8 +22,13 @@ class HeartbeatEndpoint internal constructor(
 
     override fun validateParams() {
         super.validateParams()
-        if (channels.isEmpty() && channelGroups.isEmpty()) {
-            throw PubNubException(PubNubError.CHANNEL_AND_GROUP_MISSING)
+        when {
+            channels.any { it.isEmpty() } || channelGroups.any { it.isEmpty() } -> {
+                throw PubNubException(PubNubError.CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING)
+            }
+            channels.isEmpty() && channelGroups.isEmpty() -> {
+                throw PubNubException(PubNubError.CHANNEL_AND_GROUP_MISSING)
+            }
         }
     }
 

--- a/pubnub-kotlin/pubnub-kotlin-impl/src/main/kotlin/com/pubnub/internal/endpoints/presence/LeaveEndpoint.kt
+++ b/pubnub-kotlin/pubnub-kotlin-impl/src/main/kotlin/com/pubnub/internal/endpoints/presence/LeaveEndpoint.kt
@@ -17,8 +17,13 @@ class LeaveEndpoint internal constructor(pubnub: PubNubImpl) : EndpointCore<Void
 
     override fun validateParams() {
         super.validateParams()
-        if (channels.isEmpty() && channelGroups.isEmpty()) {
-            throw PubNubException(PubNubError.CHANNEL_AND_GROUP_MISSING)
+        when {
+            channels.any { it.isEmpty() } || channelGroups.any { it.isEmpty() } -> {
+                throw PubNubException(PubNubError.CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING)
+            }
+            channels.isEmpty() && channelGroups.isEmpty() -> {
+                throw PubNubException(PubNubError.CHANNEL_AND_GROUP_MISSING)
+            }
         }
     }
 

--- a/pubnub-kotlin/pubnub-kotlin-impl/src/test/kotlin/com/pubnub/api/legacy/endpoints/HeartbeatCoreEndpointTest.kt
+++ b/pubnub-kotlin/pubnub-kotlin-impl/src/test/kotlin/com/pubnub/api/legacy/endpoints/HeartbeatCoreEndpointTest.kt
@@ -142,27 +142,42 @@ class HeartbeatCoreEndpointTest : BaseTest() {
         config.presenceTimeout = 123
         // initPubNub()
 
-        stubFor(
-            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/ch1/heartbeat"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
-                        {
-                          "status": 200,
-                          "message": "OK",
-                          "service": "Presence"
-                        }
-                        """.trimIndent(),
-                    ),
-                ),
-        )
-
         try {
             HeartbeatEndpoint(pubnub).sync()
             failTest()
         } catch (e: Exception) {
             assertPnException(
                 PubNubError.CHANNEL_AND_GROUP_MISSING,
+                e,
+            )
+        }
+    }
+
+    @Test
+    fun testChannelListContainsOnlyEmptyStringSync() {
+        config.presenceTimeout = 123
+
+        try {
+            HeartbeatEndpoint(pubnub, channels = listOf("", "channel1")).sync()
+            failTest()
+        } catch (e: Exception) {
+            assertPnException(
+                PubNubError.CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING,
+                e,
+            )
+        }
+    }
+
+    @Test
+    fun testChannelGroupListContainsOnlyEmptyStringSync() {
+        config.presenceTimeout = 123
+
+        try {
+            HeartbeatEndpoint(pubnub, channelGroups = listOf("", "channelGroup1")).sync()
+            failTest()
+        } catch (e: Exception) {
+            assertPnException(
+                PubNubError.CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING,
                 e,
             )
         }
@@ -198,23 +213,7 @@ class HeartbeatCoreEndpointTest : BaseTest() {
     @Test
     fun testBlankSubKeySync() {
         config.presenceTimeout = 123
-
-        stubFor(
-            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/ch1/heartbeat"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
-                        {
-                          "status": 200,
-                          "message": "OK",
-                          "service": "Presence"
-                        }
-                        """.trimIndent(),
-                    ),
-                ),
-        )
         config.subscribeKey = " "
-        // initPubNub()
 
         try {
             HeartbeatEndpoint(pubnub, listOf("ch1")).sync()
@@ -230,23 +229,7 @@ class HeartbeatCoreEndpointTest : BaseTest() {
     @Test
     fun testEmptySubKeySync() {
         config.presenceTimeout = 123
-
-        stubFor(
-            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/ch1/heartbeat"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
-                        {
-                          "status": 200,
-                          "message": "OK",
-                          "service": "Presence"
-                        }
-                        """.trimIndent(),
-                    ),
-                ),
-        )
         config.subscribeKey = ""
-        // initPubNub()
 
         try {
             HeartbeatEndpoint(pubnub, listOf("ch1")).sync()

--- a/pubnub-kotlin/pubnub-kotlin-impl/src/test/kotlin/com/pubnub/api/legacy/endpoints/presence/LeaveTest.kt
+++ b/pubnub-kotlin/pubnub-kotlin-impl/src/test/kotlin/com/pubnub/api/legacy/endpoints/presence/LeaveTest.kt
@@ -189,22 +189,6 @@ class LeaveTest : BaseTest() {
 
     @Test
     fun testMissingChannelAndGroupSync() {
-        stubFor(
-            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/coolChannel/leave"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
-                        {
-                          "status": 200,
-                          "message": "OK",
-                          "service": "Presence",
-                          "action": "leave"
-                        }
-                        """.trimIndent(),
-                    ),
-                ),
-        )
-
         try {
             LeaveEndpoint(pubnub).apply {}.sync()
         } catch (e: Exception) {
@@ -214,22 +198,6 @@ class LeaveTest : BaseTest() {
 
     @Test
     fun testBlankSubKeySync() {
-        stubFor(
-            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/coolChannel/leave"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
-                        {
-                          "status": 200,
-                          "message": "OK",
-                          "service": "Presence",
-                          "action": "leave"
-                        }
-                        """.trimIndent(),
-                    ),
-                ),
-        )
-
         config.subscribeKey = " "
 
         try {
@@ -241,22 +209,6 @@ class LeaveTest : BaseTest() {
 
     @Test
     fun testEmptySubKeySync() {
-        stubFor(
-            get(urlPathEqualTo("/v2/presence/sub-key/mySubscribeKey/channel/coolChannel/leave"))
-                .willReturn(
-                    aResponse().withBody(
-                        """
-                        {
-                          "status": 200,
-                          "message": "OK",
-                          "service": "Presence",
-                          "action": "leave"
-                        }
-                        """.trimIndent(),
-                    ),
-                ),
-        )
-
         config.subscribeKey = ""
 
         try {
@@ -293,5 +245,27 @@ class LeaveTest : BaseTest() {
         val requests = findAll(getRequestedFor(urlMatching("/.*")))
         assertEquals(1, requests.size)
         assertEquals("myKey", requests[0].queryParameter("auth").firstValue())
+    }
+
+    @Test
+    fun testChannelListContainsOnlyEmptyStringSync() {
+        try {
+            LeaveEndpoint(pubnub).apply {
+                channels = listOf("", "coolChannel2")
+            }.sync()
+        } catch (e: Exception) {
+            assertPnException(PubNubError.CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING, e)
+        }
+    }
+
+    @Test
+    fun testChannelGroupListContainsOnlyEmptyStringSync() {
+        try {
+            LeaveEndpoint(pubnub).apply {
+                channelGroups = listOf("", "group1")
+            }.sync()
+        } catch (e: Exception) {
+            assertPnException(PubNubError.CHANNEL_AND_GROUP_CONTAINS_EMPTY_STRING, e)
+        }
     }
 }


### PR DESCRIPTION
to ensure users receive an error when providing empty strings for channels or groups.