### PR TITLE
Deprecated grant method.

### DIFF
--- a/pubnub-kotlin/pubnub-kotlin-api/src/jvmMain/kotlin/com/pubnub/api/PubNub.kt
+++ b/pubnub-kotlin/pubnub-kotlin-api/src/jvmMain/kotlin/com/pubnub/api/PubNub.kt
@@ -1002,6 +1002,13 @@ actual interface PubNub : StatusEmitter, EventEmitter {
      *
      *                      It's possible to grant permissions to multiple [channelGroups] simultaneously.
      */
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "This function is deprecated. Use the grantToken(ttl, meta, authorizedUUID, channels, channelGroups, uuids)",
+        replaceWith = ReplaceWith(
+            "grantToken(ttl, meta, authorizedUUID, channels, channelGroups, uuids)"
+        )
+    )
     fun grant(
         read: Boolean = false,
         write: Boolean = false,
@@ -1017,6 +1024,13 @@ actual interface PubNub : StatusEmitter, EventEmitter {
     /**
      * See [grant]
      */
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "This function is deprecated. Use the grantToken(ttl, meta, authorizedUUID, channels, channelGroups, uuids)",
+        replaceWith = ReplaceWith(
+            "grantToken(ttl, meta, authorizedUUID, channels, channelGroups, uuids)"
+        )
+    )
     fun grant(
         read: Boolean = false,
         write: Boolean = false,

--- a/pubnub-kotlin/pubnub-kotlin-impl/src/integrationTest/kotlin/com/pubnub/api/integration/ObjectsIntegrationTest.kt
+++ b/pubnub-kotlin/pubnub-kotlin-impl/src/integrationTest/kotlin/com/pubnub/api/integration/ObjectsIntegrationTest.kt
@@ -568,6 +568,36 @@ class ObjectsIntegrationTest : BaseIntegrationTest() {
     }
 
     @Test
+    fun canSetChannelMemberWhenReferentialIntegrityIsEnabled() {
+        // before calling setChannelMembers we need to set channel metadata
+        pubnub.setChannelMetadata(
+            channel = channel,
+            name = randomValue(15),
+            status = status01,
+            type = type01,
+        ).sync()
+
+        // before calling setChannelMembers we need to set user metadata
+        pubnub.setUUIDMetadata(
+            uuid = testUserId01,
+            name = randomValue(15),
+            status = status01,
+            type = type01,
+        ).sync()
+
+        val result: PNMemberArrayResult = pubnub.setChannelMembers(
+            channel = channel,
+            users = listOf(PNMember.Partial(uuidId = testUserId01, status = status01, type = type01)),
+            include = MemberInclude(
+                includeStatus = true,
+                includeType = true,
+            )
+        ).sync()
+
+        assertEquals(testUserId01, result.data.first().uuid.id)
+    }
+
+    @Test
     fun testManageMember() {
         pubnub.setChannelMembers(
             channel = channel,


### PR DESCRIPTION
Added test to show setChannelMember behaviour when referential integrity is enabled.