### PR TITLE
Excluded build-time dependencies from Snyk scan.

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -24,4 +24,4 @@ jobs:
           JAVA_HOME_21_ARM64: ""
         with:
           command: monitor
-          args: --org=sdk --all-sub-projects
+          args: --org=sdk --all-sub-projects --configuration-matching=^(?!.*([tT]est|dokka|swiftExport)).*Classpath$

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx_coroutines"}
 
 # tests
-wiremock = { module = "com.github.tomakehurst:wiremock", version = "2.27.2" }
+wiremock = { module = "com.github.tomakehurst:wiremock-jre8", version = "2.35.2" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
 cucumber-java = { module = "io.cucumber:cucumber-java", version.ref = "cucumber" }


### PR DESCRIPTION
Updated Wiremock lib to the latest tha support java 8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined security scanning process to focus on relevant configurations.
  * Updated test infrastructure dependencies to newer versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->