### PR TITLE
Fixed max api level for Android

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Run Snyk monitor for vulnerabilities
-        uses: snyk/actions/gradle-8-jdk21@9adf32b1121593767fc3c057af55b55db032dc04 # master
+        uses: snyk/actions/gradle-8-jdk21@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_SDK_TOKEN }}
           # Snyk Gradle actions run in a container; inheriting the runner's JAVA_HOME

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -24,4 +24,4 @@ jobs:
           JAVA_HOME_21_ARM64: ""
         with:
           command: monitor
-          args: --org=sdk --all-sub-projects --configuration-matching=^(?!.*([tT]est|dokka|swiftExport)).*Classpath$
+          args: "--org=sdk --all-sub-projects --configuration-matching='^(?!.*([tT]est|dokka|swiftExport)).*Classpath$'"

--- a/.pubnub.yml
+++ b/.pubnub.yml
@@ -31,11 +31,11 @@ sdks:
                     runtime-version:
                       - ART
                     target-api-level: 
-                      - 23
+                      - 36
                     minimum-api-level:
                       - 23
                     maximum-api-level:
-                      - 30  
+                      - 36
                     target-architecture:
                       - armeabi-v7a
                       - atom
@@ -57,7 +57,7 @@ sdks:
                     minimum-os-version:
                       - macOS 10.12
                     maximum-os-version:
-                      - macOS 15.0.1
+                      - macOS 26.4.1
                     target-architecture:
                       - x86-64
                   Windows:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android SDK platform targeting to API level 36 (minimum remains 23).
  * Updated macOS SDK platform targeting to macOS 26.4.1.
  * Updated CI workflow: Snyk Gradle action now tracks the master branch and adjusted argument quoting to preserve regex and ensure correct input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->