### PR TITLE
Add LogContentConfig examples for Java and Kotlin (#409)

### DIFF
--- a/pubnub-gson/pubnub-gson-docs/src/main/java/com/pubnub/docs/logging/LogContentConfigApp.java
+++ b/pubnub-gson/pubnub-gson-docs/src/main/java/com/pubnub/docs/logging/LogContentConfigApp.java
@@ -1,0 +1,44 @@
+package com.pubnub.docs.logging;
+// https://www.pubnub.com/docs/sdks/java/logging#log-content-configuration
+
+import com.pubnub.api.UserId;
+import com.pubnub.api.java.PubNub;
+import com.pubnub.api.java.v2.PNConfiguration;
+import com.pubnub.api.logging.LogContentConfig;
+
+public class LogContentConfigApp {
+    public static void main(String[] args) throws Exception {
+        // snippet.logContentConfigDefault
+        PNConfiguration config = PNConfiguration.builder(new UserId("demoUserId"), "demo")
+                .publishKey("demo")
+                .logContentConfig(new LogContentConfig(1000, 4000))
+                .build();
+
+        PubNub pubnub = PubNub.create(config);
+        // snippet.end
+
+        // snippet.logContentConfigSuppressMessages
+        PNConfiguration configSuppressMessages = PNConfiguration.builder(new UserId("demoUserId"), "demo")
+                .publishKey("demo")
+                .logContentConfig(new LogContentConfig(
+                        0,
+                        LogContentConfig.DEFAULT_LOGGED_HTTP_RESPONSE_MAX_BYTES
+                ))
+                .build();
+
+        PubNub pubnubSuppressMessages = PubNub.create(configSuppressMessages);
+        // snippet.end
+
+        // snippet.logContentConfigUnlimitedResponse
+        PNConfiguration configUnlimitedResponse = PNConfiguration.builder(new UserId("demoUserId"), "demo")
+                .publishKey("demo")
+                .logContentConfig(new LogContentConfig(
+                        LogContentConfig.DEFAULT_LOGGED_MESSAGE_CONTENT_MAX_BYTES,
+                        Integer.MAX_VALUE
+                ))
+                .build();
+
+        PubNub pubnubUnlimitedResponse = PubNub.create(configUnlimitedResponse);
+        // snippet.end
+    }
+}

--- a/pubnub-gson/pubnub-gson-docs/src/main/java/com/pubnub/docs/logging/LogContentConfigApp.java
+++ b/pubnub-gson/pubnub-gson-docs/src/main/java/com/pubnub/docs/logging/LogContentConfigApp.java
@@ -6,9 +6,16 @@ import com.pubnub.api.java.PubNub;
 import com.pubnub.api.java.v2.PNConfiguration;
 import com.pubnub.api.logging.LogContentConfig;
 
+/**
+ * Demonstrates LogContentConfig usage for controlling what gets logged in PubNub SDK.
+ * Shows three different configurations: default byte limits, suppressed message content, and unlimited HTTP responses.
+ */
 public class LogContentConfigApp {
+    /**
+     * Main entry point demonstrating three LogContentConfig patterns.
+     */
     public static void main(String[] args) throws Exception {
-        // snippet.logContentConfigDefault
+        // snippet.logContentConfigCustom
         PNConfiguration config = PNConfiguration.builder(new UserId("demoUserId"), "demo")
                 .publishKey("demo")
                 .logContentConfig(new LogContentConfig(1000, 4000))
@@ -16,6 +23,7 @@ public class LogContentConfigApp {
 
         PubNub pubnub = PubNub.create(config);
         // snippet.end
+        pubnub.destroy();
 
         // snippet.logContentConfigSuppressMessages
         PNConfiguration configSuppressMessages = PNConfiguration.builder(new UserId("demoUserId"), "demo")
@@ -28,6 +36,7 @@ public class LogContentConfigApp {
 
         PubNub pubnubSuppressMessages = PubNub.create(configSuppressMessages);
         // snippet.end
+        pubnubSuppressMessages.destroy();
 
         // snippet.logContentConfigUnlimitedResponse
         PNConfiguration configUnlimitedResponse = PNConfiguration.builder(new UserId("demoUserId"), "demo")
@@ -40,5 +49,6 @@ public class LogContentConfigApp {
 
         PubNub pubnubUnlimitedResponse = PubNub.create(configUnlimitedResponse);
         // snippet.end
+        pubnubUnlimitedResponse.destroy();
     }
 }

--- a/pubnub-gson/pubnub-gson-docs/src/main/java/com/pubnub/docs/logging/LogContentConfigApp.java
+++ b/pubnub-gson/pubnub-gson-docs/src/main/java/com/pubnub/docs/logging/LogContentConfigApp.java
@@ -8,7 +8,7 @@ import com.pubnub.api.logging.LogContentConfig;
 
 /**
  * Demonstrates LogContentConfig usage for controlling what gets logged in PubNub SDK.
- * Shows three different configurations: default byte limits, suppressed message content, and unlimited HTTP responses.
+ * Shows three different configurations: custom byte limits, suppressed message content, and unlimited HTTP responses.
  */
 public class LogContentConfigApp {
     /**

--- a/pubnub-kotlin/pubnub-kotlin-docs/src/main/kotlin/com/pubnub/docs/logging/LogContentConfigMain.kt
+++ b/pubnub-kotlin/pubnub-kotlin-docs/src/main/kotlin/com/pubnub/docs/logging/LogContentConfigMain.kt
@@ -22,7 +22,7 @@ fun main() {
 
     val pubnub = PubNub.create(config)
     // snippet.end
-    pubnub.close()
+    pubnub.destroy()
 
     // snippet.logContentConfigSuppressMessages
     val configSuppressMessages = PNConfiguration.builder(UserId("demoUserId"), "demo") {
@@ -34,7 +34,7 @@ fun main() {
 
     val pubnubSuppressMessages = PubNub.create(configSuppressMessages)
     // snippet.end
-    pubnubSuppressMessages.close()
+    pubnubSuppressMessages.destroy()
 
     // snippet.logContentConfigUnlimitedResponse
     val configUnlimitedResponse = PNConfiguration.builder(UserId("demoUserId"), "demo") {
@@ -46,5 +46,5 @@ fun main() {
 
     val pubnubUnlimitedResponse = PubNub.create(configUnlimitedResponse)
     // snippet.end
-    pubnubUnlimitedResponse.close()
+    pubnubUnlimitedResponse.destroy()
 }

--- a/pubnub-kotlin/pubnub-kotlin-docs/src/main/kotlin/com/pubnub/docs/logging/LogContentConfigMain.kt
+++ b/pubnub-kotlin/pubnub-kotlin-docs/src/main/kotlin/com/pubnub/docs/logging/LogContentConfigMain.kt
@@ -1,0 +1,43 @@
+package com.pubnub.docs.logging
+// https://www.pubnub.com/docs/sdks/kotlin/logging#log-content-configuration
+
+import com.pubnub.api.PubNub
+import com.pubnub.api.UserId
+import com.pubnub.api.logging.LogContentConfig
+import com.pubnub.api.v2.PNConfiguration
+
+fun main() {
+    // snippet.logContentConfigDefault
+    val config = PNConfiguration.builder(UserId("demoUserId"), "demo") {
+        publishKey = "demo"
+        logContentConfig = LogContentConfig(
+            loggedMessageContentMaxBytes = 1000,
+            loggedHttpResponseMaxBytes = 4000,
+        )
+    }.build()
+
+    val pubnub = PubNub.create(config)
+    // snippet.end
+
+    // snippet.logContentConfigSuppressMessages
+    val configSuppressMessages = PNConfiguration.builder(UserId("demoUserId"), "demo") {
+        publishKey = "demo"
+        logContentConfig = LogContentConfig(
+            loggedMessageContentMaxBytes = 0,
+        )
+    }.build()
+
+    val pubnubSuppressMessages = PubNub.create(configSuppressMessages)
+    // snippet.end
+
+    // snippet.logContentConfigUnlimitedResponse
+    val configUnlimitedResponse = PNConfiguration.builder(UserId("demoUserId"), "demo") {
+        publishKey = "demo"
+        logContentConfig = LogContentConfig(
+            loggedHttpResponseMaxBytes = Int.MAX_VALUE,
+        )
+    }.build()
+
+    val pubnubUnlimitedResponse = PubNub.create(configUnlimitedResponse)
+    // snippet.end
+}

--- a/pubnub-kotlin/pubnub-kotlin-docs/src/main/kotlin/com/pubnub/docs/logging/LogContentConfigMain.kt
+++ b/pubnub-kotlin/pubnub-kotlin-docs/src/main/kotlin/com/pubnub/docs/logging/LogContentConfigMain.kt
@@ -6,8 +6,12 @@ import com.pubnub.api.UserId
 import com.pubnub.api.logging.LogContentConfig
 import com.pubnub.api.v2.PNConfiguration
 
+/**
+ * Demonstrates LogContentConfig usage for controlling what gets logged in PubNub SDK.
+ * Shows three different configurations: custom byte limits, suppressed message content, and unlimited HTTP responses.
+ */
 fun main() {
-    // snippet.logContentConfigDefault
+    // snippet.logContentConfigCustom
     val config = PNConfiguration.builder(UserId("demoUserId"), "demo") {
         publishKey = "demo"
         logContentConfig = LogContentConfig(
@@ -18,6 +22,7 @@ fun main() {
 
     val pubnub = PubNub.create(config)
     // snippet.end
+    pubnub.close()
 
     // snippet.logContentConfigSuppressMessages
     val configSuppressMessages = PNConfiguration.builder(UserId("demoUserId"), "demo") {
@@ -29,6 +34,7 @@ fun main() {
 
     val pubnubSuppressMessages = PubNub.create(configSuppressMessages)
     // snippet.end
+    pubnubSuppressMessages.close()
 
     // snippet.logContentConfigUnlimitedResponse
     val configUnlimitedResponse = PNConfiguration.builder(UserId("demoUserId"), "demo") {
@@ -40,4 +46,5 @@ fun main() {
 
     val pubnubUnlimitedResponse = PubNub.create(configUnlimitedResponse)
     // snippet.end
+    pubnubUnlimitedResponse.close()
 }


### PR DESCRIPTION
* Introduced LogContentConfigApp in Java to demonstrate logging configuration options.
* Added LogContentConfigMain in Kotlin with similar logging configuration examples.
* Both files showcase how to set up logging for message content and HTTP responses using the PubNub SDK.